### PR TITLE
[SDK-113]: Added X-SDK identifier to headers sent in HTTP requests

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+SDK_IDENTIFIER = "Python"

--- a/yoti_python_sdk/client.py
+++ b/yoti_python_sdk/client.py
@@ -10,6 +10,8 @@ from os.path import isfile, expanduser
 import requests
 from past.builtins import basestring
 
+from config import SDK_IDENTIFIER
+
 import yoti_python_sdk
 from yoti_python_sdk.activity_details import ActivityDetails
 from yoti_python_sdk.crypto import Crypto
@@ -93,6 +95,7 @@ class Client(object):
         return {
             'X-Yoti-Auth-Key': self.__crypto.get_public_key(),
             'X-Yoti-Auth-Digest': self.__crypto.sign('GET&' + path),
+            'X-SDK': SDK_IDENTIFIER,
             'Content-Type': 'application/json',
             'Accept': 'application/json'
         }

--- a/yoti_python_sdk/tests/test_client.py
+++ b/yoti_python_sdk/tests/test_client.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     import mock
 
+from config import SDK_IDENTIFIER
+
 from yoti_python_sdk import YOTI_API_ENDPOINT
 from yoti_python_sdk import Client
 from yoti_python_sdk.client import NO_KEY_FILE_SPECIFIED_ERROR
@@ -36,7 +38,8 @@ def expected_headers(x_yoti_auth_key, x_yoti_auth_digest):
         'Content-Type': 'application/json',
         'Accept': 'application/json',
         'X-Yoti-Auth-Key': x_yoti_auth_key,
-        'X-Yoti-Auth-Digest': x_yoti_auth_digest
+        'X-Yoti-Auth-Digest': x_yoti_auth_digest,
+        'X-SDK': SDK_IDENTIFIER
     }
 
 


### PR DESCRIPTION
Since the identifier is referenced from both the code and the tests, I placed it in a config file, implemented in the same style as the conftest.py which is currently used. Tests pass after this change. 