### PR TITLE
[SDK-167]: Removed tests from package output

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include yoti/tests/fixtures/*
-recursive-include yoti/protobuf/v1/definitions *.proto
+prune yoti_python_sdk/tests
+recursive-include yoti_python_sdk/protobuf/v1/definitions *.proto

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
-VERSION = '2.0.2'
+VERSION = '2.0.3'
 long_description = 'This package contains the tools you need to quickly ' \
                    'integrate your Python back-end with Yoti, so that your ' \
                    'users can share their identity details with your ' \


### PR DESCRIPTION
Changed tests to be pruned in the manifest file.  Example projects already are not included.