### PR TITLE
SDK-711: Add ParentRememberMeID

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ client = Client(YOTI_CLIENT_SDK_ID, YOTI_KEY_FILE_PATH)
 activity_details = client.get_activity_details(token)
 
 profile = activity_details.profile
-		
+        
 selfie = profile.selfie.value
 given_names = profile.given_names.value
 family_name = profile.family_name.value
@@ -131,8 +131,9 @@ postal_address = profile.postal_address.value
 gender = profile.gender.value
 nationality = profile.nationality.value
 email_address = profile.email_address.value
-		
+        
 remember_me_id = activity_details.user_id
+parent_remember_me_id = activity_details.parent_remember_me_id
 receipt_id = activity_details.receipt_id
 timestamp = activity_details.timestamp
 base64_selfie_uri = activity_details.base64_selfie_uri
@@ -281,6 +282,7 @@ For information on testing with multiple Python versions, see [VERSION-SUPPORT.m
 
 * Activity Details
     * [X] Remember Me ID `user_id`
+    * [X] Parent Remember Me ID `parent_remember_me_id`
     * [X] ReceiptID `receipt_id`
     * [X] Timestamp `timestamp`
     * [X] Profile `profile`

--- a/examples/yoti_example_django/yoti_example/templates/profile.html
+++ b/examples/yoti_example_django/yoti_example/templates/profile.html
@@ -46,6 +46,12 @@
             <td>{{user_id}}</td>
         </tr>
         {% endif %}
+        {% if parent_remember_me_id %}
+        <tr>
+            <th scope="row">Parent Remember Me ID</th>
+            <td>{{parent_remember_me_id}}</td>
+        </tr>
+        {% endif %}
         {% if given_names %}
         <tr>
             <th scope="row">Given Name(s)</th>

--- a/examples/yoti_example_django/yoti_example/views.py
+++ b/examples/yoti_example_django/yoti_example/views.py
@@ -30,6 +30,7 @@ class AuthView(TemplateView):
         context = profile_dict.get('attributes')
         context['base64_selfie_uri'] = getattr(activity_details, 'base64_selfie_uri')
         context['user_id'] = getattr(activity_details, 'user_id')
+        context['parent_remember_me_id'] = getattr(activity_details, 'parent_remember_me_id')
         context['receipt_id'] = getattr(activity_details, 'receipt_id')
         context['timestamp'] = getattr(activity_details, 'timestamp')
 

--- a/examples/yoti_example_flask/app.py
+++ b/examples/yoti_example_flask/app.py
@@ -41,6 +41,7 @@ def auth():
     context = profile_dict.get('attributes')
     context['base64_selfie_uri'] = getattr(activity_details, 'base64_selfie_uri')
     context['user_id'] = getattr(activity_details, 'user_id')
+    context['parent_remember_me_id'] = getattr(activity_details, 'parent_remember_me_id')
     context['receipt_id'] = getattr(activity_details, 'receipt_id')
     context['timestamp'] = getattr(activity_details, 'timestamp')
 

--- a/examples/yoti_example_flask/templates/profile.html
+++ b/examples/yoti_example_flask/templates/profile.html
@@ -46,6 +46,12 @@
             <td>{{user_id}}</td>
         </tr>
         {% endif %}
+        {% if parent_remember_me_id %}
+        <tr>
+            <th scope="row">Parent Remember Me ID</th>
+            <td>{{parent_remember_me_id}}</td>
+        </tr>
+        {% endif %}
         {% if given_names %}
         <tr>
             <th scope="row">Given Name(s)</th>

--- a/yoti_python_sdk/activity_details.py
+++ b/yoti_python_sdk/activity_details.py
@@ -39,6 +39,7 @@ class ActivityDetails:
             self.ensure_postal_address()
 
         self.user_id = receipt.get('remember_me_id')
+        self.parent_remember_me_id = receipt.get('parent_remember_me_id')
         self.outcome = receipt.get('sharing_outcome')
         self.receipt_id = receipt.get('receipt_id')
         timestamp = receipt.get('timestamp')
@@ -86,6 +87,7 @@ class ActivityDetails:
 
     def __iter__(self):
         yield 'user_id', self.user_id
+        yield 'parent_remember_me_id', self.parent_remember_me_id
         yield 'outcome', self.outcome
         yield 'receipt_id', self.receipt_id
         yield 'user_profile', self.user_profile

--- a/yoti_python_sdk/tests/conftest.py
+++ b/yoti_python_sdk/tests/conftest.py
@@ -46,6 +46,11 @@ def user_id():
 
 
 @pytest.fixture(scope='module')
+def parent_remember_me_id():
+    return 'f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8'
+
+
+@pytest.fixture(scope='module')
 def receipt_id():
     return 'Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN'
 
@@ -58,6 +63,7 @@ def timestamp():
 @pytest.fixture(scope='module')
 def successful_receipt():
     return {'remember_me_id': user_id(),
+            'parent_remember_me_id': parent_remember_me_id(),
             'receipt_id': receipt_id(),
             'timestamp': timestamp(),
             'sharing_outcome': 'SUCCESS'}
@@ -68,6 +74,13 @@ def failure_receipt():
     return {'remember_me_id': user_id(),
             'sharing_outcome': 'FAILURE',
             'timestamp': timestamp()}
+
+
+@pytest.fixture(scope='module')
+def empty_strings():
+    return {'remember_me_id': '',
+            'parent_remember_me_id': '',
+            'sharing_outcome': ''}
 
 
 @pytest.fixture(scope='module')

--- a/yoti_python_sdk/tests/test_activity_details.py
+++ b/yoti_python_sdk/tests/test_activity_details.py
@@ -8,7 +8,8 @@ from datetime import datetime
 from yoti_python_sdk import config
 from yoti_python_sdk.activity_details import ActivityDetails
 from yoti_python_sdk.protobuf.v1.protobuf import Protobuf
-from yoti_python_sdk.tests.conftest import successful_receipt, failure_receipt, no_values_receipt, user_id
+from yoti_python_sdk.tests.conftest import successful_receipt, failure_receipt, \
+    no_values_receipt, user_id, parent_remember_me_id, empty_strings
 
 ADDRESS_FORMAT_KEY = "address_format"
 ADDRESS_FORMAT_VALUE = 1
@@ -115,6 +116,32 @@ def test_missing_values_handled():
     activity_details = ActivityDetails(no_values_receipt())
 
     assert isinstance(activity_details, ActivityDetails)
+
+
+def test_remember_me_id_empty():
+    activity_details = ActivityDetails(empty_strings())
+
+    assert activity_details.user_id == ''
+    assert isinstance(activity_details, ActivityDetails)
+
+
+def test_remember_me_id_valid():
+    activity_details = ActivityDetails(successful_receipt())
+
+    assert activity_details.user_id == user_id()
+
+
+def test_parent_remember_me_id_empty():
+    activity_details = ActivityDetails(empty_strings())
+
+    assert activity_details.user_id == ''
+    assert isinstance(activity_details, ActivityDetails)
+
+
+def test_parent_remember_me_id_valid():
+    activity_details = ActivityDetails(successful_receipt())
+
+    assert activity_details.parent_remember_me_id == parent_remember_me_id()
 
 
 def test_try_parse_age_verified_field_age_over():


### PR DESCRIPTION
- Test coverage for `remember_me_id` (called `user_id` until the major release) were limited to the tests contained in the "successful_receipt" tests, so I added a couple of small unit tests for that which cover the same functionality as `parent_remember_me_id` too
- Line changes in the README were just changing tabs to spaces