### PR TITLE
SDK-781: Add timezone information

### DIFF
--- a/yoti_python_sdk/activity_details.py
+++ b/yoti_python_sdk/activity_details.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import collections
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from yoti_python_sdk import config
 from yoti_python_sdk.profile import Profile
@@ -45,7 +45,7 @@ class ActivityDetails:
         timestamp = receipt.get('timestamp')
 
         if timestamp is not None:
-            self.timestamp = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ')
+            self.timestamp = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=timezone.utc)
 
     def try_parse_selfie_field(self, field):
         self.base64_selfie_uri = Protobuf().image_uri_based_on_content_type(

--- a/yoti_python_sdk/anchor.py
+++ b/yoti_python_sdk/anchor.py
@@ -114,7 +114,7 @@ class Anchor:
         signed_timestamp_object.MergeFromString(self.__signed_timestamp)
 
         try:
-            signed_timestamp_parsed = datetime.datetime.fromtimestamp(
+            signed_timestamp_parsed = datetime.datetime.utcfromtimestamp(
                 signed_timestamp_object.timestamp / float(1000000))
         except OSError:
             print("Unable to parse timestamp from integer: '{0}'".format(signed_timestamp_object.timestamp))

--- a/yoti_python_sdk/tests/test_activity_details.py
+++ b/yoti_python_sdk/tests/test_activity_details.py
@@ -3,7 +3,7 @@ import collections
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 from yoti_python_sdk import config
 from yoti_python_sdk.activity_details import ActivityDetails
@@ -109,7 +109,7 @@ def test_failure_receipt_handled():
 
     assert activity_details.user_id == user_id()
     assert activity_details.outcome == "FAILURE"
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33, tzinfo=timezone.utc)
 
 
 def test_missing_values_handled():

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -10,7 +10,7 @@ def test_parse_anchors_driving_license():
     parsed_anchor = anchor_parser.get_driving_license_anchor()
 
     assert parsed_anchor.anchor_type == config.ANCHOR_SOURCE
-    assert parsed_anchor.signed_timestamp == datetime.datetime(2018, 4, 11, 13, 13, 3, 923537)
+    assert parsed_anchor.signed_timestamp == datetime.datetime(2018, 4, 11, 12, 13, 3, 923537)
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "DRIVING_LICENCE"
     assert parsed_anchor.origin_server_certs.serial_number == int("46131813624213904216516051554755262812")
@@ -20,7 +20,7 @@ def test_parse_anchors_passport():
     parsed_anchor = anchor_parser.get_passport_anchor()
 
     assert parsed_anchor.anchor_type == config.ANCHOR_SOURCE
-    assert parsed_anchor.signed_timestamp == datetime.datetime(2018, 4, 12, 14, 14, 32, 835537)
+    assert parsed_anchor.signed_timestamp == datetime.datetime(2018, 4, 12, 13, 14, 32, 835537)
     assert parsed_anchor.sub_type == "OCR"
     assert parsed_anchor.value == "PASSPORT"
     assert parsed_anchor.origin_server_certs.serial_number == int("277870515583559162487099305254898397834")
@@ -30,7 +30,7 @@ def test_parse_yoti_admin():
     parsed_anchor = anchor_parser.get_yoti_admin_anchor()
 
     assert parsed_anchor.anchor_type == config.ANCHOR_VERIFIER
-    assert parsed_anchor.signed_timestamp == datetime.datetime(2018, 4, 11, 13, 13, 4, 95238)
+    assert parsed_anchor.signed_timestamp == datetime.datetime(2018, 4, 11, 12, 13, 4, 95238)
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "YOTI_ADMIN"
     assert parsed_anchor.origin_server_certs.serial_number == int("256616937783084706710155170893983549581")

--- a/yoti_python_sdk/tests/test_client.py
+++ b/yoti_python_sdk/tests/test_client.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from os import environ
 
 import pytest
@@ -153,7 +153,7 @@ def test_requesting_activity_details_with_correct_data(
 
     assert activity_details.user_id == "ijH4kkqMKTG0FSNUgQIvd2Z3Nx1j8f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrN"
     assert activity_details.receipt_id == "Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN"
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33, tzinfo=timezone.utc)
 
     selfie_user_profile = activity_details.user_profile.get(config.ATTRIBUTE_SELFIE)
     assert isinstance(selfie_user_profile, basestring)
@@ -178,7 +178,7 @@ def test_requesting_activity_details_with_null_profile(
     mock_get.assert_called_once_with(url=expected_activity_details_url, headers=expected_get_headers)
     assert activity_details.user_id == "ijH4kkqMKTG0FSNUgQIvd2Z3Nx1j8f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrN"
     assert activity_details.receipt_id == "Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN"
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33, tzinfo=timezone.utc)
     assert isinstance(activity_details, ActivityDetails)
 
 
@@ -193,7 +193,7 @@ def test_requesting_activity_details_with_empty_profile(
     mock_get.assert_called_once_with(url=expected_activity_details_url, headers=expected_get_headers)
     assert activity_details.user_id == "ijH4kkqMKTG0FSNUgQIvd2Z3Nx1j8f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrN"
     assert activity_details.receipt_id == "Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN"
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33, tzinfo=timezone.utc)
     assert isinstance(activity_details, ActivityDetails)
 
 
@@ -208,7 +208,7 @@ def test_requesting_activity_details_with_missing_profile(
     mock_get.assert_called_once_with(url=expected_activity_details_url, headers=expected_get_headers)
     assert activity_details.user_id == "ijH4kkqMKTG0FSNUgQIvd2Z3Nx1j8f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrN"
     assert activity_details.receipt_id == "Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN"
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33, tzinfo=timezone.utc)
     assert isinstance(activity_details, ActivityDetails)
 
 


### PR DESCRIPTION
See here for information on Python DateTime - https://docs.python.org/3/library/datetime.html

Our time zones were "naive", which meant they had no timezone information attached to them. This meant the tests were failing when run in a different timezone. This change adds the fact that they are UTC to the timezones, so they are now "aware".

We have to think about whether anyone may have been making any assumptions about the timezone, and what this change would mean if the were.