### PR TITLE
SDK-781: Anchor timestamp tests

### DIFF
--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -4,6 +4,7 @@ from yoti_python_sdk import config
 from yoti_python_sdk.tests import anchor_parser
 from datetime import datetime
 
+
 def test_parse_anchors_driving_license():
     parsed_anchor = anchor_parser.get_driving_license_anchor()
 
@@ -12,6 +13,7 @@ def test_parse_anchors_driving_license():
     assert parsed_anchor.value == "DRIVING_LICENCE"
     assert parsed_anchor.origin_server_certs.serial_number == int("46131813624213904216516051554755262812")
     assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 11, 12, 13, 3, 923537)
+
 
 def test_parse_anchors_passport():
     parsed_anchor = anchor_parser.get_passport_anchor()
@@ -22,6 +24,7 @@ def test_parse_anchors_passport():
     assert parsed_anchor.origin_server_certs.serial_number == int("277870515583559162487099305254898397834")
     assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 12, 13, 14, 32, 835537)
 
+
 def test_parse_yoti_admin():
     parsed_anchor = anchor_parser.get_yoti_admin_anchor()
 
@@ -30,6 +33,7 @@ def test_parse_yoti_admin():
     assert parsed_anchor.value == "YOTI_ADMIN"
     assert parsed_anchor.origin_server_certs.serial_number == int("256616937783084706710155170893983549581")
     assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 11, 12, 13, 4, 95238)
+
 
 def test_anchor_returns_correct_default_values():
     anchor = yoti_python_sdk.anchor.Anchor()

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -2,7 +2,7 @@
 import yoti_python_sdk
 from yoti_python_sdk import config
 from yoti_python_sdk.tests import anchor_parser
-from datetime import datetime, timezone
+from datetime import datetime
 
 def test_parse_anchors_driving_license():
     parsed_anchor = anchor_parser.get_driving_license_anchor()

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -2,7 +2,7 @@
 import yoti_python_sdk
 from yoti_python_sdk import config
 from yoti_python_sdk.tests import anchor_parser
-
+from datetime import datetime, timezone
 
 def test_parse_anchors_driving_license():
     parsed_anchor = anchor_parser.get_driving_license_anchor()
@@ -11,7 +11,7 @@ def test_parse_anchors_driving_license():
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "DRIVING_LICENCE"
     assert parsed_anchor.origin_server_certs.serial_number == int("46131813624213904216516051554755262812")
-
+    assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 11, 12, 13, 3, 923537)
 
 def test_parse_anchors_passport():
     parsed_anchor = anchor_parser.get_passport_anchor()
@@ -20,7 +20,7 @@ def test_parse_anchors_passport():
     assert parsed_anchor.sub_type == "OCR"
     assert parsed_anchor.value == "PASSPORT"
     assert parsed_anchor.origin_server_certs.serial_number == int("277870515583559162487099305254898397834")
-
+    assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 12, 13, 14, 32, 835537)
 
 def test_parse_yoti_admin():
     parsed_anchor = anchor_parser.get_yoti_admin_anchor()
@@ -29,7 +29,7 @@ def test_parse_yoti_admin():
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "YOTI_ADMIN"
     assert parsed_anchor.origin_server_certs.serial_number == int("256616937783084706710155170893983549581")
-
+    assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 11, 12, 13, 4, 95238)
 
 def test_anchor_returns_correct_default_values():
     anchor = yoti_python_sdk.anchor.Anchor()

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -3,6 +3,16 @@ import yoti_python_sdk
 from yoti_python_sdk import config
 from yoti_python_sdk.tests import anchor_parser
 from datetime import datetime
+import time
+
+
+def utc_offset():
+    utc_offset = int(time.timezone / 60 / 60)
+
+    if time.daylight:
+        utc_offset = utc_offset - time.daylight
+
+    return utc_offset
 
 
 def test_parse_anchors_driving_license():
@@ -12,7 +22,7 @@ def test_parse_anchors_driving_license():
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "DRIVING_LICENCE"
     assert parsed_anchor.origin_server_certs.serial_number == int("46131813624213904216516051554755262812")
-    assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 11, 12, 13, 3, 923537)
+    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 11, 12 - utc_offset(), 13, 3, 923537)
 
 
 def test_parse_anchors_passport():
@@ -22,7 +32,7 @@ def test_parse_anchors_passport():
     assert parsed_anchor.sub_type == "OCR"
     assert parsed_anchor.value == "PASSPORT"
     assert parsed_anchor.origin_server_certs.serial_number == int("277870515583559162487099305254898397834")
-    assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 12, 13, 14, 32, 835537)
+    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 12, 13 - utc_offset(), 14, 32, 835537)
 
 
 def test_parse_yoti_admin():
@@ -32,7 +42,7 @@ def test_parse_yoti_admin():
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "YOTI_ADMIN"
     assert parsed_anchor.origin_server_certs.serial_number == int("256616937783084706710155170893983549581")
-    assert datetime.utcfromtimestamp(parsed_anchor.signed_timestamp.timestamp()) == datetime(2018, 4, 11, 12, 13, 4, 95238)
+    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 11, 12 - utc_offset(), 13, 4, 95238)
 
 
 def test_anchor_returns_correct_default_values():


### PR DESCRIPTION
- Tests run in any timezone (considers DST)
- Works in Python 2.7 and 3.x