### PR TITLE
SDK-662: Add try blocks to anchor parsing, tidy up tests

### DIFF
--- a/yoti_python_sdk/tests/anchor_parser.py
+++ b/yoti_python_sdk/tests/anchor_parser.py
@@ -11,7 +11,7 @@ ANCHOR_PASSPORT = join(FIXTURES_DIR, 'anchor_passport.txt')
 ANCHOR_YOTI_ADMIN = join(FIXTURES_DIR, 'anchor_yoti_admin.txt')
 
 
-def parse_anchor_from_base64_text(file_path):
+def get_anchor_from_base64_text(file_path):
     base64_driving_license_anchor = read_file(file_path)
     driving_license_anchor_bytes = binascii.a2b_base64(base64_driving_license_anchor)
 
@@ -19,19 +19,19 @@ def parse_anchor_from_base64_text(file_path):
     anchors = list()
     anchors.append(protobuf_anchor)
 
-    return anchor.Anchor().parse_anchors(anchors)[0]
+    return anchors
 
 
-def get_driving_license_anchor():
-    return parse_anchor_from_base64_text(ANCHOR_DRIVING_LICENSE)
+def get_parsed_driving_license_anchor():
+    return anchor.Anchor().parse_anchors(get_anchor_from_base64_text(ANCHOR_DRIVING_LICENSE))[0]
 
 
-def get_passport_anchor():
-    return parse_anchor_from_base64_text(ANCHOR_PASSPORT)
+def get_parsed_passport_anchor():
+    return anchor.Anchor().parse_anchors(get_anchor_from_base64_text(ANCHOR_PASSPORT))[0]
 
 
-def get_yoti_admin_anchor():
-    return parse_anchor_from_base64_text(ANCHOR_YOTI_ADMIN)
+def get_parsed_yoti_admin_anchor():
+    return anchor.Anchor().parse_anchors(get_anchor_from_base64_text(ANCHOR_YOTI_ADMIN))[0]
 
 
 def read_file(file_path):

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -1,12 +1,17 @@
 # -*- coding: utf-8 -*-
+import logging
+import time
+from datetime import datetime
+
+from yoti_python_sdk.protobuf.attribute_public_api import Attribute_pb2
+
 import yoti_python_sdk
 from yoti_python_sdk import config
+from yoti_python_sdk.anchor import Anchor
 from yoti_python_sdk.tests import anchor_parser
-from datetime import datetime
-import time
 
 
-def utc_offset():
+def get_utc_offset():
     utc_offset = int(time.timezone / 60 / 60)
 
     if time.daylight:
@@ -16,40 +21,62 @@ def utc_offset():
 
 
 def test_parse_anchors_driving_license():
-    parsed_anchor = anchor_parser.get_driving_license_anchor()
+    parsed_anchor = anchor_parser.get_parsed_driving_license_anchor()
 
     assert parsed_anchor.anchor_type == config.ANCHOR_SOURCE
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "DRIVING_LICENCE"
     assert parsed_anchor.origin_server_certs.serial_number == int("46131813624213904216516051554755262812")
-    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 11, 12 - utc_offset(), 13, 3, 923537)
+    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 11, 12 - get_utc_offset(), 13, 3, 923537)
 
 
 def test_parse_anchors_passport():
-    parsed_anchor = anchor_parser.get_passport_anchor()
+    parsed_anchor = anchor_parser.get_parsed_passport_anchor()
 
     assert parsed_anchor.anchor_type == config.ANCHOR_SOURCE
     assert parsed_anchor.sub_type == "OCR"
     assert parsed_anchor.value == "PASSPORT"
     assert parsed_anchor.origin_server_certs.serial_number == int("277870515583559162487099305254898397834")
-    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 12, 13 - utc_offset(), 14, 32, 835537)
+    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 12, 13 - get_utc_offset(), 14, 32, 835537)
 
 
 def test_parse_yoti_admin():
-    parsed_anchor = anchor_parser.get_yoti_admin_anchor()
+    parsed_anchor = anchor_parser.get_parsed_yoti_admin_anchor()
 
     assert parsed_anchor.anchor_type == config.ANCHOR_VERIFIER
     assert parsed_anchor.sub_type == ""
     assert parsed_anchor.value == "YOTI_ADMIN"
     assert parsed_anchor.origin_server_certs.serial_number == int("256616937783084706710155170893983549581")
-    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 11, 12 - utc_offset(), 13, 4, 95238)
+    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 11, 12 - get_utc_offset(), 13, 4, 95238)
 
 
 def test_anchor_returns_correct_default_values():
-    anchor = yoti_python_sdk.anchor.Anchor()
+    default_anchor = yoti_python_sdk.anchor.Anchor()
 
-    assert anchor.anchor_type == "Unknown"
-    assert anchor.signed_timestamp is None
-    assert anchor.sub_type == ""
-    assert anchor.value == ""
-    assert anchor.origin_server_certs is None
+    assert default_anchor.anchor_type == "Unknown"
+    assert default_anchor.signed_timestamp is None
+    assert default_anchor.sub_type == ""
+    assert default_anchor.value == ""
+    assert default_anchor.origin_server_certs is None
+
+
+def test_error_parsing_anchor_certificate_carries_on_parsing():
+    driving_license_anchor = anchor_parser.get_anchor_from_base64_text(anchor_parser.ANCHOR_DRIVING_LICENSE)[0]
+    anchors = list()
+    anchors.append(Attribute_pb2.Anchor())
+    anchors.append(driving_license_anchor)
+
+    # 1st anchor will log a warning when being parsed
+    logger = logging.getLogger()
+    logger.propagate = False
+    parsed_anchors = Anchor.parse_anchors(anchors)
+    logger.propagate = True
+
+    assert len(parsed_anchors) == 1
+
+    parsed_anchor = parsed_anchors[0]
+    assert parsed_anchor.anchor_type == config.ANCHOR_SOURCE
+    assert parsed_anchor.sub_type == ""
+    assert parsed_anchor.value == "DRIVING_LICENCE"
+    assert parsed_anchor.origin_server_certs.serial_number == int("46131813624213904216516051554755262812")
+    assert parsed_anchor.signed_timestamp == datetime(2018, 4, 11, 12 - get_utc_offset(), 13, 3, 923537)

--- a/yoti_python_sdk/tests/test_attribute.py
+++ b/yoti_python_sdk/tests/test_attribute.py
@@ -36,7 +36,7 @@ def test_attribute_get_verifiers():
 
 
 def create_source_and_verifier_anchors():
-    passport_anchor = anchor_parser.get_passport_anchor()  # source
-    yoti_admin_anchor = anchor_parser.get_yoti_admin_anchor()  # verifier
+    passport_anchor = anchor_parser.get_parsed_passport_anchor()  # source
+    yoti_admin_anchor = anchor_parser.get_parsed_yoti_admin_anchor()  # verifier
 
     return [passport_anchor, yoti_admin_anchor]


### PR DESCRIPTION
- Ensured any anchor can be parsed, and won't affect parsing of other anchors
- renamed a few methods to make it clearer what they're doing (updated utc_offset name as it shadowed utc_offset in outer scope)