### PR TITLE
SDK-856: Allow empty for string content types only

### DIFF
--- a/yoti_python_sdk/anchor.py
+++ b/yoti_python_sdk/anchor.py
@@ -52,8 +52,9 @@ class Anchor:
                                                           origin_server_certs_item).to_cryptography()
 
                 except Exception as exc:
-                    logging.warning(
-                        'Error loading anchor certificate, exception: {0} - {1}'.format(type(exc).__name__, exc))
+                    if logging.getLogger().propagate:
+                        logging.warning(
+                            'Error loading anchor certificate, exception: {0} - {1}'.format(type(exc).__name__, exc))
                     continue
 
                 for i in range(len(crypto_cert.extensions)):
@@ -71,8 +72,9 @@ class Anchor:
                                     parsed_anchors = Anchor.get_values_from_extensions(anc, anchor_type, extensions,
                                                                                        crypto_cert, parsed_anchors)
                     except Exception as exc:
-                        logging.warning('Error parsing anchor certificate extension, exception: {0} - {1}'.format(
-                            type(exc).__name__, exc))
+                        if logging.getLogger().propagate:
+                            logging.warning('Error parsing anchor certificate extension, exception: {0} - {1}'.format(
+                                type(exc).__name__, exc))
                         continue
 
         return parsed_anchors

--- a/yoti_python_sdk/profile.py
+++ b/yoti_python_sdk/profile.py
@@ -23,10 +23,13 @@ class Profile:
 
                     self.attributes[field.name] = Attribute(field.name, value, anchors)
 
-                except Exception as exc:
-                    error = 'Error parsing profile attribute: "{0}"'.format(field.name)
+                except ValueError as ve:
                     if logging.getLogger().propagate:
-                        logging.warning('error: {0}, exception: {1} - {2}'.format(error, type(exc).__name__, exc))
+                        logging.warning(ve)
+                except Exception as exc:
+                    if logging.getLogger().propagate:
+                        logging.warning(
+                            'Error parsing profile attribute:{0}, exception: {1} - {2}'.format(field.name, type(exc).__name__, exc))
 
             self.ensure_postal_address()
 

--- a/yoti_python_sdk/protobuf/protobuf.py
+++ b/yoti_python_sdk/protobuf/protobuf.py
@@ -47,6 +47,8 @@ class Protobuf(object):
     def value_based_on_content_type(self, value, content_type=None):
         if content_type == self.CT_STRING:
             return value.decode('utf-8')
+        elif value == b'':
+            raise ValueError("Content type: '{0}' should not have an empty value".format(content_type))
         elif content_type == self.CT_DATE:
             return value.decode('utf-8')
         elif content_type == self.CT_JPEG \

--- a/yoti_python_sdk/tests/test_profile.py
+++ b/yoti_python_sdk/tests/test_profile.py
@@ -134,6 +134,42 @@ def test_error_parsing_attribute_has_none_value():
     assert profile.get_attribute(int_attribute_name) is None
 
 
+@pytest.mark.parametrize("content_type", [Protobuf.CT_DATE, Protobuf.CT_INT, Protobuf.CT_JPEG, Protobuf.CT_PNG, Protobuf.CT_JSON, Protobuf.CT_UNDEFINED])
+def test_parse_empty_values_returns_none(content_type):
+    attribute_name = "attribute_name"
+
+    attribute_list = create_single_attribute_list(
+        name=attribute_name,
+        value=b'',
+        anchors=None,
+        content_type=content_type)
+
+    # disable logging for the below call: warning logged as value is empty
+    logger = logging.getLogger()
+    logger.propagate = False
+
+    profile = Profile(attribute_list)
+
+    logger.propagate = True
+
+    assert profile.get_attribute(attribute_name) is None
+
+
+@pytest.mark.parametrize("value", [b'', "".encode()])
+def test_parse_empty_string_value_returns_attribute(value):
+    attribute_name = "attribute_name"
+
+    attribute_list = create_single_attribute_list(
+        name=attribute_name,
+        value=value,
+        anchors=None,
+        content_type=Protobuf.CT_STRING)
+
+    profile = Profile(attribute_list)
+
+    assert profile.get_attribute(attribute_name).value == ""
+
+
 def test_error_parsing_attribute_does_not_affect_other_attribute():
     string_attribute_name = "string_attribute"
     int_attribute_name = "int_attribute"


### PR DESCRIPTION
- Only CT_STRING attributes should allow an empty value
- ApplicationProfile hasn't been added to Python SDK yet, but once it does, we will need to add the exception for ApplicationLogo
- Added extra propagation check to logging from other PR