### PR TITLE
SDK-594: new Image type

### DIFF
--- a/yoti_python_sdk/activity_details.py
+++ b/yoti_python_sdk/activity_details.py
@@ -26,10 +26,11 @@ class ActivityDetails:
                         field.content_type
                     )
 
-                    self.user_profile[field.name] = value
-
                     if field.name == config.ATTRIBUTE_SELFIE:
                         self.try_parse_selfie_field(field)
+                        value = field.value
+
+                    self.user_profile[field.name] = value
 
                     if field.name.startswith(config.ATTRIBUTE_AGE_OVER) or field.name.startswith(
                             config.ATTRIBUTE_AGE_UNDER):

--- a/yoti_python_sdk/image.py
+++ b/yoti_python_sdk/image.py
@@ -3,11 +3,15 @@ from yoti_python_sdk.protobuf.protobuf import Protobuf
 
 class Image:
     def __init__(self, image_bytes, image_content_type):
-        if image_content_type == Protobuf.CT_JPEG or image_content_type == Protobuf.CT_PNG:
+        if image_content_type in Image.allowed_types():
             self.__data = image_bytes
             self.__content_type = image_content_type
         else:
             raise TypeError("Content type '{0}' is not a supported image type".format(image_content_type))
+
+    @staticmethod
+    def allowed_types():
+        return [Protobuf.CT_PNG, Protobuf.CT_JPEG]
 
     @property
     def data(self):

--- a/yoti_python_sdk/image.py
+++ b/yoti_python_sdk/image.py
@@ -1,0 +1,32 @@
+from yoti_python_sdk.protobuf.protobuf import Protobuf
+
+
+class Image:
+    def __init__(self, image_bytes, image_content_type):
+        if image_content_type == Protobuf.CT_JPEG or image_content_type == Protobuf.CT_PNG:
+            self.__data = image_bytes
+            self.__content_type = image_content_type
+        else:
+            raise TypeError("Content type '{0}' is not a supported image type".format(image_content_type))
+
+    @property
+    def data(self):
+        return self.__data
+
+    @property
+    def content_type(self):
+        return self.__content_type
+
+    def mime_type(self):
+        if self.__content_type == Protobuf.CT_JPEG:
+            return "image/jpeg"
+        elif self.__content_type == Protobuf.CT_PNG:
+            return "image/png"
+        else:
+            return ""
+
+    def base64_content(self):
+        return Protobuf().image_uri_based_on_content_type(
+            # TODO: move image_uri_based_on_content_type method to this class
+            self.__data,
+            self.__content_type)

--- a/yoti_python_sdk/profile.py
+++ b/yoti_python_sdk/profile.py
@@ -20,11 +20,10 @@ class Profile:
                         field.content_type
                     )
 
-                    # first condition will be removed in v3.0.0, so selfie also returns an Image object
-                    if field.name != config.ATTRIBUTE_SELFIE and \
-                            (field.content_type == Protobuf.CT_JPEG \
-                             or field.content_type == Protobuf.CT_PNG):
-                        value = Image(field.value, field.content_type)
+                    # this will be removed in v3.0.0, so selfie also returns an Image object
+                    if field.content_type in Image.allowed_types():
+                        if field.name == config.ATTRIBUTE_SELFIE:
+                            value = field.value
 
                     anchors = Anchor().parse_anchors(field.anchors)
 

--- a/yoti_python_sdk/profile.py
+++ b/yoti_python_sdk/profile.py
@@ -4,6 +4,7 @@ import logging
 from yoti_python_sdk import config
 from yoti_python_sdk.anchor import Anchor
 from yoti_python_sdk.attribute import Attribute
+from yoti_python_sdk.image import Image
 from yoti_python_sdk.protobuf.protobuf import Protobuf
 
 
@@ -18,6 +19,12 @@ class Profile:
                         field.value,
                         field.content_type
                     )
+
+                    # first condition will be removed in v3.0.0, so selfie also returns an Image object
+                    if field.name != config.ATTRIBUTE_SELFIE and \
+                            (field.content_type == Protobuf.CT_JPEG \
+                             or field.content_type == Protobuf.CT_PNG):
+                        value = Image(field.value, field.content_type)
 
                     anchors = Anchor().parse_anchors(field.anchors)
 

--- a/yoti_python_sdk/protobuf/protobuf.py
+++ b/yoti_python_sdk/protobuf/protobuf.py
@@ -45,15 +45,15 @@ class Protobuf(object):
         return anchor
 
     def value_based_on_content_type(self, value, content_type=None):
+        from yoti_python_sdk.image import Image
         if content_type == self.CT_STRING:
             return value.decode('utf-8')
         elif value == b'':
             raise ValueError("Content type: '{0}' should not have an empty value".format(content_type))
         elif content_type == self.CT_DATE:
             return value.decode('utf-8')
-        elif content_type == self.CT_JPEG \
-                or content_type == self.CT_PNG:
-            return value
+        elif content_type in Image.allowed_types():
+            return Image(value, content_type)
         elif content_type == self.CT_JSON:
             return self.convert_to_dict(value)
         elif content_type == self.CT_INT:

--- a/yoti_python_sdk/tests/test_image.py
+++ b/yoti_python_sdk/tests/test_image.py
@@ -1,0 +1,26 @@
+import pytest
+
+from yoti_python_sdk.image import Image
+from yoti_python_sdk.protobuf.protobuf import Protobuf
+
+
+def test_image_with_unsupported_type():
+    with pytest.raises(TypeError):
+        Image(b'', Protobuf.CT_UNDEFINED)
+
+
+@pytest.mark.parametrize("content_type, expected_mime_type",
+                         [(Protobuf.CT_JPEG, 'image/jpeg'),
+                          (Protobuf.CT_PNG, 'image/png')])
+def test_image_mime_type(content_type, expected_mime_type):
+    image = Image(b'', content_type)
+
+    assert image.mime_type() == expected_mime_type
+
+
+@pytest.mark.parametrize("content_type, expected_base64_content",
+                         [(Protobuf.CT_JPEG, 'data:image/jpeg;base64,dGVzdCBzdHJpbmc='),
+                          (Protobuf.CT_PNG, 'data:image/png;base64,dGVzdCBzdHJpbmc=')])
+def test_image_base64_content(content_type, expected_base64_content):
+    image = Image(b'test string', content_type)
+    assert image.base64_content() == expected_base64_content

--- a/yoti_python_sdk/tests/test_protobuf.py
+++ b/yoti_python_sdk/tests/test_protobuf.py
@@ -5,9 +5,9 @@ import pytest
 
 from yoti_python_sdk.protobuf import protobuf
 
-string_value = "123"
-byte_value = str.encode(string_value)
-int_value = int(string_value)
+STRING_VALUE = "123"
+BYTE_VALUE = str.encode(STRING_VALUE)
+INT_VALUE = int(STRING_VALUE)
 
 
 @pytest.fixture(scope='module')
@@ -17,27 +17,27 @@ def proto():
 
 @pytest.mark.parametrize(
     "content_type, expected_value",
-    [(proto().CT_STRING, string_value),
-     (proto().CT_DATE, string_value),
-     (proto().CT_INT, int_value)])
+    [(proto().CT_STRING, STRING_VALUE),
+     (proto().CT_DATE, STRING_VALUE),
+     (proto().CT_INT, INT_VALUE)])
 def test_protobuf_values_based_on_content_type(content_type, expected_value):
-    result = proto().value_based_on_content_type(byte_value, content_type)
+    result = proto().value_based_on_content_type(BYTE_VALUE, content_type)
     assert result == expected_value
 
 
-def test_warning_protobuf_values_based_on_content_type(proto):
+def test_protobuf_values_based_on_other_content_types(proto):
     # disable logging for the below types: warning shown as type is not recognized
     logger = logging.getLogger()
     logger.propagate = False
 
-    result = proto.value_based_on_content_type(byte_value, proto.CT_UNDEFINED)
-    assert result == string_value
+    result = proto.value_based_on_content_type(BYTE_VALUE, proto.CT_UNDEFINED)
+    assert result == STRING_VALUE
 
-    result = proto.value_based_on_content_type(byte_value)
-    assert result == string_value
+    result = proto.value_based_on_content_type(BYTE_VALUE)
+    assert result == STRING_VALUE
 
-    result = proto.value_based_on_content_type(byte_value, 100)
-    assert result == string_value
+    result = proto.value_based_on_content_type(BYTE_VALUE, 100)
+    assert result == STRING_VALUE
 
     logger.propagate = True
 
@@ -47,8 +47,8 @@ def test_warning_protobuf_values_based_on_content_type(proto):
     (proto().CT_JPEG,
      proto().CT_PNG))
 def test_image_value_based_on_content_type(proto, content_type):
-    result = proto.value_based_on_content_type(byte_value, content_type)
-    assert result.data == byte_value
+    result = proto.value_based_on_content_type(BYTE_VALUE, content_type)
+    assert result.data == BYTE_VALUE
     assert result.content_type == content_type
 
 

--- a/yoti_python_sdk/tests/test_protobuf.py
+++ b/yoti_python_sdk/tests/test_protobuf.py
@@ -5,32 +5,27 @@ import pytest
 
 from yoti_python_sdk.protobuf import protobuf
 
+string_value = "123"
+byte_value = str.encode(string_value)
+int_value = int(string_value)
+
 
 @pytest.fixture(scope='module')
 def proto():
     return protobuf.Protobuf()
 
 
-def test_protobuf_value_based_on_content_type(proto):
-    string_value = "123"
-    byte_value = str.encode(string_value)
-    int_value = int(string_value)
+@pytest.mark.parametrize(
+    "content_type, expected_value",
+    [(proto().CT_STRING, string_value),
+     (proto().CT_DATE, string_value),
+     (proto().CT_INT, int_value)])
+def test_protobuf_values_based_on_content_type(content_type, expected_value):
+    result = proto().value_based_on_content_type(byte_value, content_type)
+    assert result == expected_value
 
-    result = proto.value_based_on_content_type(byte_value, proto.CT_STRING)
-    assert result == string_value
 
-    result = proto.value_based_on_content_type(byte_value, proto.CT_DATE)
-    assert result == string_value
-
-    result = proto.value_based_on_content_type(byte_value, proto.CT_JPEG)
-    assert result == byte_value
-
-    result = proto.value_based_on_content_type(byte_value, proto.CT_PNG)
-    assert result == byte_value
-
-    result = proto.value_based_on_content_type(byte_value, proto.CT_INT)
-    assert result == int_value
-
+def test_warning_protobuf_values_based_on_content_type(proto):
     # disable logging for the below types: warning shown as type is not recognized
     logger = logging.getLogger()
     logger.propagate = False
@@ -45,6 +40,16 @@ def test_protobuf_value_based_on_content_type(proto):
     assert result == string_value
 
     logger.propagate = True
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    (proto().CT_JPEG,
+     proto().CT_PNG))
+def test_image_value_based_on_content_type(proto, content_type):
+    result = proto.value_based_on_content_type(byte_value, content_type)
+    assert result.data == byte_value
+    assert result.content_type == content_type
 
 
 def test_protobuf_image_uri_based_on_content_type(proto):


### PR DESCRIPTION
- Creating the new Image object before we add the DocumentImages attribute
- I have left Image.base64_content calling Protobuf().image_uri_based_on_content_type in this PR, as that has moved on my other branch. When I rebase the other branch I will change the location of this (so will leave the TODO in there until then) 
- Since selfie currently is just an attribute with the byte value as the value (retrieved with selfie.value), and base64URL is retrieved from the ActivityDetails, we can't make a non-breaking change to the object that is returned. When we do the major release, I will change the selfie to return this new Image object. 
