### PR TITLE
SDK-826: Verify SSL and API Endpoint Environment Variables

### DIFF
--- a/yoti_python_sdk/__init__.py
+++ b/yoti_python_sdk/__init__.py
@@ -21,6 +21,7 @@ ver_path = convert_path(version_path)
 with open(ver_path) as ver_file:
     exec(ver_file.read(), main_ns)
 
+<<<<<<< HEAD
 __version__ = main_ns["__version__"]
 YOTI_API_URL = environ.get("YOTI_API_URL", DEFAULTS["YOTI_API_URL"])
 YOTI_API_PORT = environ.get("YOTI_API_PORT", DEFAULTS["YOTI_API_PORT"])
@@ -28,6 +29,13 @@ YOTI_API_VERSION = environ.get("YOTI_API_VERSION", DEFAULTS["YOTI_API_VERSION"])
 YOTI_API_ENDPOINT = "{0}:{1}/api/{2}".format(
     YOTI_API_URL, YOTI_API_PORT, YOTI_API_VERSION
 )
+=======
+__version__ = main_ns['__version__']
+YOTI_API_URL = environ.get('YOTI_API_URL', DEFAULTS['YOTI_API_URL'])
+YOTI_API_PORT = environ.get('YOTI_API_PORT', DEFAULTS['YOTI_API_PORT'])
+YOTI_API_VERSION = environ.get('YOTI_API_VERSION', DEFAULTS['YOTI_API_VERSION'])
+YOTI_API_ENDPOINT = environ.get('YOTI_API_ENDPOINT', '{0}:{1}/api/{2}'.format(YOTI_API_URL, YOTI_API_PORT, YOTI_API_VERSION))
+>>>>>>> SDK-826: Add environment variable to allow overriding of whole endpoint
 
 YOTI_API_VERIFY_SSL = environ.get("YOTI_API_VERIFY_SSL", DEFAULTS["YOTI_API_VERIFY_SSL"])
 if YOTI_API_VERIFY_SSL == "false":

--- a/yoti_python_sdk/__init__.py
+++ b/yoti_python_sdk/__init__.py
@@ -9,6 +9,7 @@ DEFAULTS = {
     "YOTI_API_URL": "https://api.yoti.com",
     "YOTI_API_PORT": 443,
     "YOTI_API_VERSION": "v1",
+    "YOTI_API_VERIFY_SSL": "true"
 }
 
 main_ns = {}
@@ -28,4 +29,13 @@ YOTI_API_ENDPOINT = "{0}:{1}/api/{2}".format(
     YOTI_API_URL, YOTI_API_PORT, YOTI_API_VERSION
 )
 
-__all__ = ["Client", __version__]
+YOTI_API_VERIFY_SSL = environ.get("YOTI_API_VERIFY_SSL", DEFAULTS["YOTI_API_VERIFY_SSL"])
+if YOTI_API_VERIFY_SSL == "false":
+    YOTI_API_VERIFY_SSL = False
+else:
+    YOTI_API_VERIFY_SSL = True
+
+__all__ = [
+    "Client",
+    __version__
+]

--- a/yoti_python_sdk/__init__.py
+++ b/yoti_python_sdk/__init__.py
@@ -21,7 +21,6 @@ ver_path = convert_path(version_path)
 with open(ver_path) as ver_file:
     exec(ver_file.read(), main_ns)
 
-<<<<<<< HEAD
 __version__ = main_ns["__version__"]
 YOTI_API_URL = environ.get("YOTI_API_URL", DEFAULTS["YOTI_API_URL"])
 YOTI_API_PORT = environ.get("YOTI_API_PORT", DEFAULTS["YOTI_API_PORT"])
@@ -29,13 +28,6 @@ YOTI_API_VERSION = environ.get("YOTI_API_VERSION", DEFAULTS["YOTI_API_VERSION"])
 YOTI_API_ENDPOINT = "{0}:{1}/api/{2}".format(
     YOTI_API_URL, YOTI_API_PORT, YOTI_API_VERSION
 )
-=======
-__version__ = main_ns['__version__']
-YOTI_API_URL = environ.get('YOTI_API_URL', DEFAULTS['YOTI_API_URL'])
-YOTI_API_PORT = environ.get('YOTI_API_PORT', DEFAULTS['YOTI_API_PORT'])
-YOTI_API_VERSION = environ.get('YOTI_API_VERSION', DEFAULTS['YOTI_API_VERSION'])
-YOTI_API_ENDPOINT = environ.get('YOTI_API_ENDPOINT', '{0}:{1}/api/{2}'.format(YOTI_API_URL, YOTI_API_PORT, YOTI_API_VERSION))
->>>>>>> SDK-826: Add environment variable to allow overriding of whole endpoint
 
 YOTI_API_VERIFY_SSL = environ.get("YOTI_API_VERIFY_SSL", DEFAULTS["YOTI_API_VERIFY_SSL"])
 if YOTI_API_VERIFY_SSL == "false":

--- a/yoti_python_sdk/__init__.py
+++ b/yoti_python_sdk/__init__.py
@@ -30,7 +30,7 @@ YOTI_API_ENDPOINT = "{0}:{1}/api/{2}".format(
 )
 
 YOTI_API_VERIFY_SSL = environ.get("YOTI_API_VERIFY_SSL", DEFAULTS["YOTI_API_VERIFY_SSL"])
-if YOTI_API_VERIFY_SSL == "false":
+if YOTI_API_VERIFY_SSL.lower() == "false":
     YOTI_API_VERIFY_SSL = False
 else:
     YOTI_API_VERIFY_SSL = True

--- a/yoti_python_sdk/client.py
+++ b/yoti_python_sdk/client.py
@@ -23,7 +23,6 @@ from .config import (
     X_YOTI_SDK_VERSION,
     JSON_CONTENT_TYPE,
 )
-from . import YOTI_API_VERIFY_SSL
 
 NO_KEY_FILE_SPECIFIED_ERROR = (
     "Please specify the correct private key file "
@@ -104,7 +103,7 @@ class Client(object):
 
         url = yoti_python_sdk.YOTI_API_ENDPOINT + endpoint
         headers = self.__get_request_headers(endpoint, http_method, body)
-        response = requests.request(http_method, url, headers=headers, data=body, verify=YOTI_API_VERIFY_SSL)
+        response = requests.request(http_method, url, headers=headers, data=body, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL)
         return response
 
     @property
@@ -136,7 +135,7 @@ class Client(object):
         path = self.__endpoint.get_activity_details_request_path(decrypted_token)
         url = yoti_python_sdk.YOTI_API_ENDPOINT + path
         headers = self.__get_request_headers(path, http_method, content)
-        response = requests.get(url=url, headers=headers, verify=YOTI_API_VERIFY_SSL)
+        response = requests.get(url=url, headers=headers, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL)
 
         self.http_error_handler(
             response, {"default": "Unsuccessful Yoti API call: {1}"}
@@ -151,7 +150,7 @@ class Client(object):
         url = yoti_python_sdk.YOTI_API_ENDPOINT + path
         headers = self.__get_request_headers(path, http_method, aml_profile_bytes)
 
-        response = requests.post(url=url, headers=headers, data=aml_profile_bytes, verify=YOTI_API_VERIFY_SSL)
+        response = requests.post(url=url, headers=headers, data=aml_profile_bytes, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL)
 
         self.http_error_handler(
             response, {"default": "Unsuccessful Yoti API call: {1}"}

--- a/yoti_python_sdk/client.py
+++ b/yoti_python_sdk/client.py
@@ -23,6 +23,7 @@ from .config import (
     X_YOTI_SDK_VERSION,
     JSON_CONTENT_TYPE,
 )
+from . import YOTI_API_VERIFY_SSL
 
 NO_KEY_FILE_SPECIFIED_ERROR = (
     "Please specify the correct private key file "
@@ -103,7 +104,7 @@ class Client(object):
 
         url = yoti_python_sdk.YOTI_API_ENDPOINT + endpoint
         headers = self.__get_request_headers(endpoint, http_method, body)
-        response = requests.request(http_method, url, headers=headers, data=body)
+        response = requests.request(http_method, url, headers=headers, data=body, verify=YOTI_API_VERIFY_SSL)
         return response
 
     @property
@@ -135,7 +136,7 @@ class Client(object):
         path = self.__endpoint.get_activity_details_request_path(decrypted_token)
         url = yoti_python_sdk.YOTI_API_ENDPOINT + path
         headers = self.__get_request_headers(path, http_method, content)
-        response = requests.get(url=url, headers=headers)
+        response = requests.get(url=url, headers=headers, verify=YOTI_API_VERIFY_SSL)
 
         self.http_error_handler(
             response, {"default": "Unsuccessful Yoti API call: {1}"}
@@ -150,7 +151,7 @@ class Client(object):
         url = yoti_python_sdk.YOTI_API_ENDPOINT + path
         headers = self.__get_request_headers(path, http_method, aml_profile_bytes)
 
-        response = requests.post(url=url, headers=headers, data=aml_profile_bytes)
+        response = requests.post(url=url, headers=headers, data=aml_profile_bytes, verify=YOTI_API_VERIFY_SSL)
 
         self.http_error_handler(
             response, {"default": "Unsuccessful Yoti API call: {1}"}

--- a/yoti_python_sdk/tests/test_client.py
+++ b/yoti_python_sdk/tests/test_client.py
@@ -164,7 +164,7 @@ def test_requesting_activity_details_with_correct_data(
     activity_details = client.get_activity_details(encrypted_request_token)
 
     mock_get.assert_called_once_with(
-        url=expected_activity_details_url, headers=expected_get_headers
+        url=expected_activity_details_url, headers=expected_get_headers, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL
     )
     assert isinstance(activity_details, ActivityDetails)
 
@@ -214,7 +214,7 @@ def test_requesting_activity_details_with_null_profile(
     activity_details = client.get_activity_details(encrypted_request_token)
 
     mock_get.assert_called_once_with(
-        url=expected_activity_details_url, headers=expected_get_headers
+        url=expected_activity_details_url, headers=expected_get_headers, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL
     )
     assert (
         activity_details.user_id
@@ -243,7 +243,7 @@ def test_requesting_activity_details_with_empty_profile(
     activity_details = client.get_activity_details(encrypted_request_token)
 
     mock_get.assert_called_once_with(
-        url=expected_activity_details_url, headers=expected_get_headers
+        url=expected_activity_details_url, headers=expected_get_headers, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL
     )
     assert (
         activity_details.user_id
@@ -272,7 +272,7 @@ def test_requesting_activity_details_with_missing_profile(
     activity_details = client.get_activity_details(encrypted_request_token)
 
     mock_get.assert_called_once_with(
-        url=expected_activity_details_url, headers=expected_get_headers
+        url=expected_activity_details_url, headers=expected_get_headers, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL
     )
     assert (
         activity_details.user_id
@@ -345,7 +345,7 @@ def test_perform_aml_check_details_with_correct_data(
     aml_profile_bytes = aml_profile_json.encode()
 
     mock_post.assert_called_once_with(
-        url=expected_aml_url, headers=expected_post_headers, data=aml_profile_bytes
+        url=expected_aml_url, headers=expected_post_headers, data=aml_profile_bytes, verify=yoti_python_sdk.YOTI_API_VERIFY_SSL
     )
 
     assert isinstance(aml_result, aml.AmlResult)


### PR DESCRIPTION
- Add environment variable support to allow SSL verification to be turned off
- Add environment variable support to allow overriding of the whole API URL.