### PR TITLE
SDK-1196: Correct mispelling of longitude in Python SDK

### DIFF
--- a/yoti_python_sdk/dynamic_sharing_service/extension/location_constraint_extension_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/extension/location_constraint_extension_builder.py
@@ -20,6 +20,10 @@ class LocationConstraintExtensionBuilder(object):
         self.__extension["content"]["expected_device_location"] = self.__device_location
 
     def with_latitude(self, latitude):
+        if not isinstance(latitude, float) and not isinstance(latitude, int):
+            raise ValueError("Latitude must be float or int")
+        if not -90 <= latitude <= 90:
+            raise ValueError("Latitude must be between -90 and 90 degrees")
         self.__device_location["latitude"] = latitude
         return self
 
@@ -32,14 +36,26 @@ class LocationConstraintExtensionBuilder(object):
         return self.with_longitude(longtitude)
 
     def with_longitude(self, longitude):
+        if not isinstance(longitude, float) and not isinstance(longitude, int):
+            raise ValueError("Lontitude must be float or int")
+        if not -180 <= longitude <= 180:
+            raise ValueError("Longitude must be between -180 and 180 degrees")
         self.__device_location["longitude"] = longitude
         return self
 
     def with_radius(self, radius):
+        if not isinstance(radius, float) and not isinstance(radius, int):
+            raise ValueError("Radius must be float or int")
+        if not 0 <= radius:
+            raise ValueError("Radius must be >= 0")
         self.__device_location["radius"] = radius
         return self
 
     def with_uncertainty(self, uncertainty):
+        if not isinstance(uncertainty, float) and not isinstance(uncertainty, int):
+            raise ValueError("Uncertainty must be float or int")
+        if not 0 <= uncertainty:
+            raise ValueError("Uncertainty must be >= 0")
         self.__device_location["max_uncertainty_radius"] = uncertainty
         return self
 

--- a/yoti_python_sdk/dynamic_sharing_service/extension/location_constraint_extension_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/extension/location_constraint_extension_builder.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from deprecated import deprecated
+
 
 class LocationConstraintExtensionBuilder(object):
     LOCATION_CONSTRAINT = "LOCATION_CONSTRAINT"
@@ -11,7 +13,7 @@ class LocationConstraintExtensionBuilder(object):
         self.__extension["content"] = {}
         self.__device_location = {
             "latitude": None,
-            "longtitude": None,
+            "longitude": None,
             "radius": None,
             "max_uncertainty_radius": None,
         }
@@ -21,8 +23,16 @@ class LocationConstraintExtensionBuilder(object):
         self.__device_location["latitude"] = latitude
         return self
 
+    @deprecated
     def with_longtitude(self, longtitude):
-        self.__device_location["longtitude"] = longtitude
+        """
+        To be removed in v3.0.0
+        Use with_longitude instead
+        """
+        return self.with_longitude(longtitude)
+
+    def with_longitude(self, longitude):
+        self.__device_location["longitude"] = longitude
         return self
 
     def with_radius(self, radius):

--- a/yoti_python_sdk/dynamic_sharing_service/extension/location_constraint_extension_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/extension/location_constraint_extension_builder.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from deprecated import deprecated
-
 
 class LocationConstraintExtensionBuilder(object):
     LOCATION_CONSTRAINT = "LOCATION_CONSTRAINT"
@@ -26,14 +24,6 @@ class LocationConstraintExtensionBuilder(object):
             raise ValueError("Latitude must be between -90 and 90 degrees")
         self.__device_location["latitude"] = latitude
         return self
-
-    @deprecated
-    def with_longtitude(self, longtitude):
-        """
-        To be removed in v3.0.0
-        Use with_longitude instead
-        """
-        return self.with_longitude(longtitude)
 
     def with_longitude(self, longitude):
         if not isinstance(longitude, float) and not isinstance(longitude, int):

--- a/yoti_python_sdk/tests/dynamic_sharing_service/extension/test_location_constraint_extension_builder.py
+++ b/yoti_python_sdk/tests/dynamic_sharing_service/extension/test_location_constraint_extension_builder.py
@@ -8,14 +8,14 @@ from yoti_python_sdk.dynamic_sharing_service.extension.location_constraint_exten
 
 def test_builds_with_given_values():
     LATITUDE = 50
-    LONGTITUDE = 99
+    LONGITUDE = 99
     RADIUS = 60
     UNCERTAINTY = 30
 
     extension = (
         LocationConstraintExtensionBuilder()
         .with_latitude(LATITUDE)
-        .with_longtitude(LONGTITUDE)
+        .with_longitude(LONGITUDE)
         .with_radius(RADIUS)
         .with_uncertainty(UNCERTAINTY)
         .build()
@@ -24,6 +24,6 @@ def test_builds_with_given_values():
     device_location = extension["content"]["expected_device_location"]
 
     assert device_location["latitude"] == LATITUDE
-    assert device_location["longtitude"] == LONGTITUDE
+    assert device_location["longitude"] == LONGITUDE
     assert device_location["radius"] == RADIUS
     assert device_location["max_uncertainty_radius"] == UNCERTAINTY

--- a/yoti_python_sdk/tests/dynamic_sharing_service/extension/test_location_constraint_extension_builder.py
+++ b/yoti_python_sdk/tests/dynamic_sharing_service/extension/test_location_constraint_extension_builder.py
@@ -4,6 +4,61 @@ from __future__ import unicode_literals
 from yoti_python_sdk.dynamic_sharing_service.extension.location_constraint_extension_builder import (
     LocationConstraintExtensionBuilder,
 )
+import pytest
+
+
+def test_longitude_validation():
+    extension = LocationConstraintExtensionBuilder()
+    with pytest.raises(ValueError):
+        extension.with_longitude(270.00)
+    with pytest.raises(ValueError):
+        extension.with_longitude(-181)
+    with pytest.raises(ValueError):
+        extension.with_longitude("27.00")
+    extension.with_longitude(180.0)
+    extension.with_longitude(-90)
+
+
+def test_latitude_validation():
+    extension = LocationConstraintExtensionBuilder()
+    with pytest.raises(ValueError):
+        extension.with_latitude(270.00)
+    with pytest.raises(ValueError):
+        extension.with_latitude(-181)
+    with pytest.raises(ValueError):
+        extension.with_latitude("27.00")
+    with pytest.raises(ValueError):
+        extension.with_latitude(91)
+    with pytest.raises(ValueError):
+        extension.with_latitude(-180)
+    extension.with_latitude(18.0)
+    extension.with_latitude(-90)
+
+
+def test_uncertainty_validation():
+    extension = LocationConstraintExtensionBuilder()
+    with pytest.raises(ValueError):
+        extension.with_uncertainty(-1)
+    with pytest.raises(ValueError):
+        extension.with_uncertainty(-0.01)
+    with pytest.raises(ValueError):
+        extension.with_uncertainty("3")
+    extension.with_uncertainty(0)
+    extension.with_uncertainty(1)
+    extension.with_uncertainty(1e3)
+
+
+def test_radius_validation():
+    extension = LocationConstraintExtensionBuilder()
+    with pytest.raises(ValueError):
+        extension.with_radius(-1)
+    with pytest.raises(ValueError):
+        extension.with_radius(-0.01)
+    with pytest.raises(ValueError):
+        extension.with_radius("3")
+    extension.with_radius(0)
+    extension.with_radius(1)
+    extension.with_radius(1e3)
 
 
 def test_builds_with_given_values():

--- a/yoti_python_sdk/tests/dynamic_sharing_service/extension/test_location_constraint_extension_builder.py
+++ b/yoti_python_sdk/tests/dynamic_sharing_service/extension/test_location_constraint_extension_builder.py
@@ -7,58 +7,56 @@ from yoti_python_sdk.dynamic_sharing_service.extension.location_constraint_exten
 import pytest
 
 
-def test_longitude_validation():
+@pytest.mark.parametrize("longitude", [270.00, -181, "27.00"])
+def test_longitude_validation_should_reject_invalid(longitude):
     extension = LocationConstraintExtensionBuilder()
     with pytest.raises(ValueError):
-        extension.with_longitude(270.00)
-    with pytest.raises(ValueError):
-        extension.with_longitude(-181)
-    with pytest.raises(ValueError):
-        extension.with_longitude("27.00")
-    extension.with_longitude(180.0)
-    extension.with_longitude(-90)
+        extension.with_longitude(longitude)
 
 
-def test_latitude_validation():
+@pytest.mark.parametrize("longitude", [180.0, -90])
+def test_longitude_vaidation_should_accept_valid(longitude):
+    extension = LocationConstraintExtensionBuilder()
+    extension.with_longitude(longitude)
+
+
+@pytest.mark.parametrize("latitude", [270.00, -181, "27.00", 91, -180])
+def test_latitude_validation_should_reject_invalid(latitude):
     extension = LocationConstraintExtensionBuilder()
     with pytest.raises(ValueError):
-        extension.with_latitude(270.00)
-    with pytest.raises(ValueError):
-        extension.with_latitude(-181)
-    with pytest.raises(ValueError):
-        extension.with_latitude("27.00")
-    with pytest.raises(ValueError):
-        extension.with_latitude(91)
-    with pytest.raises(ValueError):
-        extension.with_latitude(-180)
-    extension.with_latitude(18.0)
-    extension.with_latitude(-90)
+        extension.with_latitude(latitude)
 
 
-def test_uncertainty_validation():
+@pytest.mark.parametrize("latitude", [18.0, -90])
+def test_latitude_validation_should_accept_valid(latitude):
+    extension = LocationConstraintExtensionBuilder()
+    extension.with_latitude(latitude)
+
+
+@pytest.mark.parametrize("uncertainty", [-1, -0.01, "3"])
+def test_uncertainty_validation_should_reject_invalid(uncertainty):
     extension = LocationConstraintExtensionBuilder()
     with pytest.raises(ValueError):
-        extension.with_uncertainty(-1)
-    with pytest.raises(ValueError):
-        extension.with_uncertainty(-0.01)
-    with pytest.raises(ValueError):
-        extension.with_uncertainty("3")
-    extension.with_uncertainty(0)
-    extension.with_uncertainty(1)
-    extension.with_uncertainty(1e3)
+        extension.with_uncertainty(uncertainty)
 
 
-def test_radius_validation():
+@pytest.mark.parametrize("uncertainty", [0, 1, 1e3])
+def test_uncertainty_validation_should_accept_valid(uncertainty):
+    extension = LocationConstraintExtensionBuilder()
+    extension.with_uncertainty(uncertainty)
+
+
+@pytest.mark.parametrize("radius", [-1, -0.01, "3"])
+def test_radius_validation_should_reject_invalid(radius):
     extension = LocationConstraintExtensionBuilder()
     with pytest.raises(ValueError):
-        extension.with_radius(-1)
-    with pytest.raises(ValueError):
-        extension.with_radius(-0.01)
-    with pytest.raises(ValueError):
-        extension.with_radius("3")
-    extension.with_radius(0)
-    extension.with_radius(1)
-    extension.with_radius(1e3)
+        extension.with_radius(radius)
+
+
+@pytest.mark.parametrize("radius", [0, 1, 1e3])
+def test_radius_validation_should_accept_valid(radius):
+    extension = LocationConstraintExtensionBuilder()
+    extension.with_radius(radius)
 
 
 def test_builds_with_given_values():


### PR DESCRIPTION
### Changed
 * Fix broken `location_constraint_extention`, misspelling of longitude causes invalid payload to be generated.