### PR TITLE
SDK-1197: Fix incorrect endpoint

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey = yoti-web-sdk:python
 sonar.projectName = python-sdk
-sonar.projectVersion = 2.9.0
+sonar.projectVersion = 2.9.1
 sonar.exclusions=yoti_python_sdk/tests/**,examples/**
 
 sonar.python.pylint.reportPath=coverage.out

--- a/yoti_python_sdk/endpoint.py
+++ b/yoti_python_sdk/endpoint.py
@@ -25,7 +25,7 @@ class Endpoint(object):
 
     def get_dynamic_share_request_url(self, no_params=False):
         if no_params:
-            return "/qrcodes/app/{appid}".format(appid=self.sdk_id)
+            return "/qrcodes/apps/{appid}".format(appid=self.sdk_id)
 
         return "/qrcodes/apps/{appid}?nonce={nonce}&timestamp={timestamp}".format(
             appid=self.sdk_id, nonce=create_nonce(), timestamp=create_timestamp()

--- a/yoti_python_sdk/profile.py
+++ b/yoti_python_sdk/profile.py
@@ -167,11 +167,15 @@ class Profile(BaseProfile):
 
     def find_age_over_verification(self, age):
         self.__find_all_age_verifications()
-        return self.verifications[config.ATTRIBUTE_AGE_OVER + str(age)]
+        if config.ATTRIBUTE_AGE_OVER + str(age) in self.verifications:
+            return self.verifications[config.ATTRIBUTE_AGE_OVER + str(age)]
+        return None
 
     def find_age_under_verification(self, age):
         self.__find_all_age_verifications()
-        return self.verifications[config.ATTRIBUTE_AGE_UNDER + str(age)]
+        if (config.ATTRIBUTE_AGE_UNDER + str(age)) in self.verifications:
+            return self.verifications[config.ATTRIBUTE_AGE_UNDER + str(age)]
+        return None
 
     def __find_all_age_verifications(self):
         if self.verifications is None:

--- a/yoti_python_sdk/tests/test_profile.py
+++ b/yoti_python_sdk/tests/test_profile.py
@@ -725,3 +725,31 @@ def test_get_age_verifications():
     age_verifications = human_profile.get_age_verifications()
 
     assert len(age_verifications) == 1
+
+
+def test_expect_none_when_no_age_over_verification_exists():
+    attribute_list = create_single_attribute_list(
+        name=config.ATTRIBUTE_GIVEN_NAMES,
+        value="Jenny",
+        anchors=None,
+        content_type=Protobuf.CT_STRING,
+    )
+
+    human_profile = Profile(attribute_list)
+
+    age_over_verification = human_profile.find_age_over_verification(18)
+    assert age_over_verification is None
+
+
+def test_expect_none_when_no_age_under_verification_exists():
+    attribute_list = create_single_attribute_list(
+        name=config.ATTRIBUTE_GIVEN_NAMES,
+        value="Jenny",
+        anchors=None,
+        content_type=Protobuf.CT_STRING,
+    )
+
+    human_profile = Profile(attribute_list)
+
+    age_under_verification = human_profile.find_age_under_verification(18)
+    assert age_under_verification is None

--- a/yoti_python_sdk/version.py
+++ b/yoti_python_sdk/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.9.0"
+__version__ = "2.9.1"


### PR DESCRIPTION
## Fixed
* Incorrect endpoint in get_dynamic_share_request_url when no_params=True
* KeyError in age verifications over/under when no age verifications were requested