### PR TITLE
SDK-1206: Remove X-Auth-Key from default headers of request builder

### DIFF
--- a/yoti_python_sdk/client.py
+++ b/yoti_python_sdk/client.py
@@ -11,6 +11,7 @@ from yoti_python_sdk.crypto import Crypto
 from yoti_python_sdk.endpoint import Endpoint
 from yoti_python_sdk.http import SignedRequest, YotiResponse
 from yoti_python_sdk.protobuf import protobuf
+from yoti_python_sdk.config import X_YOTI_AUTH_KEY
 
 NO_KEY_FILE_SPECIFIED_ERROR = (
     "Please specify the correct private key file "
@@ -138,6 +139,7 @@ class Client(object):
             .with_base_url(yoti_python_sdk.YOTI_API_ENDPOINT)
             .with_endpoint(path)
             .with_param("appId", self.sdk_id)
+            .with_header(X_YOTI_AUTH_KEY, self.__crypto.get_public_key())
             .with_request_handler(self.__request_handler)
             .build()
         )

--- a/yoti_python_sdk/http.py
+++ b/yoti_python_sdk/http.py
@@ -1,7 +1,6 @@
 from yoti_python_sdk.crypto import Crypto
 from yoti_python_sdk.utils import create_nonce, create_timestamp
 from yoti_python_sdk.config import (
-    X_YOTI_AUTH_KEY,
     X_YOTI_AUTH_DIGEST,
     X_YOTI_SDK,
     SDK_IDENTIFIER,
@@ -254,7 +253,6 @@ class SignedRequestBuilder(object):
         sdk_version = yoti_python_sdk.__version__
 
         default = {
-            X_YOTI_AUTH_KEY: self.__crypto.get_public_key(),
             X_YOTI_AUTH_DIGEST: self.__crypto.sign(request),
             X_YOTI_SDK: SDK_IDENTIFIER,
             X_YOTI_SDK_VERSION: "{0}-{1}".format(SDK_IDENTIFIER, sdk_version),

--- a/yoti_python_sdk/tests/test_http.py
+++ b/yoti_python_sdk/tests/test_http.py
@@ -31,7 +31,7 @@ def valid_endpoint():
 
 @pytest.fixture(scope="module")
 def expected_request_headers():
-    return ["X-Yoti-Auth-Key", "X-Yoti-Auth-Digest", "X-Yoti-SDK", "X-Yoti-SDK-Version"]
+    return ["X-Yoti-Auth-Digest", "X-Yoti-SDK", "X-Yoti-SDK-Version"]
 
 
 def test_create_signed_request_get_required_properties(


### PR DESCRIPTION
### Changed
 * `X-Auth-Key` removed from `SignedRequest`'s default headers
 * `X-Auth-Key` being set by business logic in `Client`