### PR TITLE
SDK-1254: Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ jobs:
     - <<: *test
       python: "3.8-dev"
     - <<: *test
+      python: "3.8"
+    - <<: *test
       stage: Coverage
       name: Coveralls
       python: "3.7"

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 asn1==2.2.0
 click==6.6
-cryptography>=2.3.0
+cryptography>=2.7.0
+cffi>=1.13.0
 future==0.15.2
 itsdangerous==0.24
 pbr==1.10.0
@@ -10,3 +11,4 @@ pytz==2018.9
 requests>=2.20.0
 urllib3>=1.24.2
 deprecated==1.2.6
+wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,13 @@
 asn1==2.2.0
 asn1crypto==0.24.0        # via cryptography
 certifi==2018.11.29       # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.13.0
 chardet==3.0.4            # via requests
 click==6.6
-cryptography==2.4.1
+cryptography==2.7
 deprecated==1.2.6
 future==0.15.2
-idna==2.7                 # via cryptography, requests
+idna==2.7                 # via requests
 itsdangerous==0.24
 pbr==1.10.0
 protobuf==3.7.0
@@ -23,6 +23,7 @@ pytz==2018.9
 requests==2.21.0
 six==1.10.0               # via cryptography, protobuf, pyopenssl
 urllib3==1.24.2
+wheel==0.24.0
 wrapt==1.11.2             # via deprecated
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
             "python-coveralls==2.9.3",
             "mock==2.0.0",
             "virtualenv==15.2",
-            "wheel==0.24.0",
         ],
     },
     classifiers=[


### PR DESCRIPTION
## Added

* Support for Python 3.8 to travis file

## Changed

* Updated `cryptography` to use >= 2.7.0 (from 2.4.0)
* Override `cffi` to use latest 1.x minor version (>= 1.13.0)