### PR TITLE
SDK-681: Date object for CT_DATE Proto

### DIFF
--- a/yoti_python_sandbox/tests/test_sandbox_client.py
+++ b/yoti_python_sandbox/tests/test_sandbox_client.py
@@ -35,7 +35,7 @@ def test_builder_should_build_client():
     assert isinstance(client, SandboxClient)
 
 
-@patch("yoti_python_sdk.sandbox.client.SandboxClient")
+@patch("yoti_python_sandbox.client.SandboxClient")
 def test_client_should_return_token_from_sandbox(sandbox_client_mock):
     sandbox_client_mock.setup_profile_share.return_value = YotiTokenResponse(
         "some-token"

--- a/yoti_python_sdk/attribute_parser.py
+++ b/yoti_python_sdk/attribute_parser.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import collections
 import json
 import logging
+import datetime
 
 from yoti_python_sdk import multivalue
 from yoti_python_sdk.protobuf.protobuf import Protobuf
@@ -19,7 +20,7 @@ def value_based_on_content_type(value, content_type=None):
             "Content type: '{0}' should not have an empty value".format(content_type)
         )
     elif content_type == Protobuf.CT_DATE:
-        return value.decode("utf-8")
+        return parse_to_date(value.decode("utf-8"))
     elif content_type in Image.allowed_types():
         return Image(value, content_type)
     elif content_type == Protobuf.CT_JSON:
@@ -39,6 +40,10 @@ def value_based_on_content_type(value, content_type=None):
         )
 
     return value.decode("utf-8")
+
+
+def parse_to_date(date_str):
+    return datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
 
 
 def convert_to_dict(byte_value):

--- a/yoti_python_sdk/tests/test_attribute_parser.py
+++ b/yoti_python_sdk/tests/test_attribute_parser.py
@@ -3,26 +3,30 @@ import logging
 
 import pytest
 
+from datetime import date
+
 from yoti_python_sdk import attribute_parser
-from yoti_python_sdk.protobuf import protobuf
+from yoti_python_sdk.protobuf.protobuf import Protobuf
 
 STRING_VALUE = "123"
 BYTE_VALUE = str.encode(STRING_VALUE)
 INT_VALUE = int(STRING_VALUE)
 
+DATE_VALUE = "1995-04-20"
+DATE_BYTE_VALUE = str.encode(DATE_VALUE)
+
+INCORRECT_DATE_VALUE = "95-222-10"
+INCORRECT_DATE_BYTE_VALUE = str.encode(INCORRECT_DATE_VALUE)
+
 
 @pytest.fixture(scope="module")
 def proto():
-    return protobuf.Protobuf()
+    return Protobuf()
 
 
 @pytest.mark.parametrize(
     "content_type, expected_value",
-    [
-        (protobuf.Protobuf.CT_STRING, STRING_VALUE),
-        (protobuf.Protobuf.CT_DATE, STRING_VALUE),
-        (protobuf.Protobuf.CT_INT, INT_VALUE),
-    ],
+    [(Protobuf.CT_STRING, STRING_VALUE), (Protobuf.CT_INT, INT_VALUE)],
 )
 def test_attribute_parser_values_based_on_content_type(content_type, expected_value):
     result = attribute_parser.value_based_on_content_type(BYTE_VALUE, content_type)
@@ -58,3 +62,21 @@ def test_jpeg_image_value_based_on_content_type(proto):
     result = attribute_parser.value_based_on_content_type(BYTE_VALUE, proto.CT_JPEG)
     assert result.data == BYTE_VALUE
     assert result.content_type == "jpeg"
+
+
+def test_date_proto_should_parse_into_date_object():
+    result = attribute_parser.value_based_on_content_type(
+        DATE_BYTE_VALUE, Protobuf.CT_DATE
+    )
+    assert isinstance(result, date)
+    assert result.strftime("%Y-%m-%d") == DATE_VALUE
+    assert result.year == 1995
+    assert result.month == 4
+    assert result.day == 20
+
+
+def test_should_raise_value_error_on_incorrect_format_date():
+    with pytest.raises(ValueError):
+        attribute_parser.value_based_on_content_type(
+            INCORRECT_DATE_BYTE_VALUE, Protobuf.CT_DATE
+        )


### PR DESCRIPTION
## Changed

* Updated all CT_DATE protobufs to be converted into a `datetime.date` object instead of just a string.