### PR TITLE
SDK-1285: Update pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-testpaths = yoti_python_sdk/tests/
+python_files = test_*.py
 norecursedirs = venv

--- a/yoti_python_sandbox/tests/test_sandbox_client.py
+++ b/yoti_python_sandbox/tests/test_sandbox_client.py
@@ -35,7 +35,7 @@ def test_builder_should_build_client():
     assert isinstance(client, SandboxClient)
 
 
-@patch("yoti_python_sdk.sandbox.client.SandboxClient")
+@patch("yoti_python_sandbox.client.SandboxClient")
 def test_client_should_return_token_from_sandbox(sandbox_client_mock):
     sandbox_client_mock.setup_profile_share.return_value = YotiTokenResponse(
         "some-token"


### PR DESCRIPTION
## Changed

* Pytest configuration changed to run all `test_*.py` files instead of specific directory (allows other modules to be added and not have to be added to the configuration)

## Fixed

* Test in sandbox fixed where old module was being patched