### PR TITLE
SDK-1281: Prevent Empty Attribute Names in Wanted Attribute

### DIFF
--- a/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
@@ -8,7 +8,7 @@ class WantedAttributeBuilder(object):
     """
 
     def __init__(self):
-        self.__attribute = {"name": None}
+        self.__attribute = {}
         self.__constraints = []
 
     def with_name(self, name):
@@ -47,7 +47,7 @@ class WantedAttributeBuilder(object):
         """
         :return: The wanted attribute object
         """
-        if self.__attribute["name"] is None or self.__attribute["name"] == "":
+        if self.__attribute.get("name", None) is None or self.__attribute["name"] == "":
             raise ValueError
         attribute = self.__attribute.copy()
         attribute["constraints"] = self.__constraints[:]

--- a/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
@@ -8,7 +8,7 @@ class WantedAttributeBuilder(object):
     """
 
     def __init__(self):
-        self.__attribute = {}
+        self.__attribute = {"name": None}
         self.__constraints = []
 
     def with_name(self, name):

--- a/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
@@ -47,8 +47,8 @@ class WantedAttributeBuilder(object):
         """
         :return: The wanted attribute object
         """
-        assert self.__attribute["name"] is not None
-        assert self.__attribute["name"] != ""
+        if self.__attribute["name"] is None or self.__attribute["name"] == "":
+            raise ValueError
         attribute = self.__attribute.copy()
         attribute["constraints"] = self.__constraints[:]
         return attribute

--- a/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/policy/wanted_attribute_builder.py
@@ -47,6 +47,8 @@ class WantedAttributeBuilder(object):
         """
         :return: The wanted attribute object
         """
+        assert self.__attribute["name"] is not None
+        assert self.__attribute["name"] != ""
         attribute = self.__attribute.copy()
         attribute["constraints"] = self.__constraints[:]
         return attribute

--- a/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_wanted_attribute_builder.py
+++ b/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_wanted_attribute_builder.py
@@ -5,6 +5,8 @@ from yoti_python_sdk.dynamic_sharing_service.policy.source_constraint_builder im
     SourceConstraintBuilder,
 )
 
+import pytest
+
 
 def test_build():
     NAME = "Test name"
@@ -45,6 +47,11 @@ def test_with_multiple_constraints():
 
     constraints = attribute["constraints"]
     assert len(constraints) == 2
+
+
+def test_missing_attribute_name_raises():
+    with pytest.raises(ValueError):
+        WantedAttributeBuilder().build()
 
 
 def test_acccept_self_assert():


### PR DESCRIPTION
### Changed
 * Add assertions to WantedAttributeBuilder.build to check that the attribute name is set and not-empty.