### PR TITLE
SDK-1288: Drop testing for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
   include:
     - &test
       stage: Test
-      python: "2.7"
+      python: "3.7"
       cache: pip
       before_install:
         - pip install -U setuptools
@@ -29,8 +29,6 @@ jobs:
       python: "3.6"
     - <<: *test
       python: "3.6-dev"
-    - <<: *test
-      python: "3.7"
     - <<: *test
       python: "3.7-dev"
     - <<: *test

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,6 @@ setup(
         "Operating System :: OS Independent",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",


### PR DESCRIPTION
## Changed

* Python 2.7 is reaching EoL at the end of December 2019 so for the major we are going to drop any future support for Python 2.
* Removed any testing for Python 2 from travis, and updated tags in setup.py