### PR TITLE
SDK-1056: Use manual path twiddling to include Yoti SDK in sys.path

### DIFF
--- a/examples/yoti_example_django/Dockerfile
+++ b/examples/yoti_example_django/Dockerfile
@@ -5,8 +5,9 @@ ARG YOTI_KEY_FILE_PATH
 RUN if [ "$YOTI_SCENARIO_ID" = "yourScenarioId" ] ; then echo YOTI_SCENARIO_ID not set; exit 1; else echo YOTI_SCENARIO_ID is $YOTI_SCENARIO_ID ; fi
 RUN if [ "$YOTI_CLIENT_SDK_ID" = "yourClientSdkId" ] ; then echo YOTI_CLIENT_SDK_ID not set; exit 1; else echo YOTI_CLIENT_SDK_ID is $YOTI_CLIENT_SDK_ID ; fi
 RUN if [ "$YOTI_KEY_FILE_PATH" = "yourKeyFilePath" ] ; then echo YOTI_KEY_FILE_PATH not set; exit 1; else echo YOTI_KEY_FILE_PATH is $YOTI_KEY_FILE_PATH ; fi
-ADD . /code
-WORKDIR /code
+ADD . /yoti-sdk
+WORKDIR /yoti-sdk/examples/yoti_example_django/
+RUN pip install --no-cache-dir -r /yoti-sdk/requirements.txt && pip install /yoti-sdk
 RUN pip install --no-cache-dir -r requirements.txt
 ENV YOTI_SCENARIO_ID $YOTI_SCENARIO_ID
 ENV YOTI_CLIENT_SDK_ID $YOTI_CLIENT_SDK_ID

--- a/examples/yoti_example_django/docker-compose.yml
+++ b/examples/yoti_example_django/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.4'
 services:
   web:
     build:
-      context: ./
+      context: ../../
+      dockerfile: examples/yoti_example_django/Dockerfile
       args:
         YOTI_SCENARIO_ID: "${YOTI_SCENARIO_ID}"
         YOTI_CLIENT_SDK_ID: "${YOTI_CLIENT_SDK_ID}"

--- a/examples/yoti_example_flask/Dockerfile
+++ b/examples/yoti_example_flask/Dockerfile
@@ -5,7 +5,8 @@ ARG YOTI_KEY_FILE_PATH
 RUN if [ "$YOTI_SCENARIO_ID" = "yourScenarioId" ] ; then echo YOTI_SCENARIO_ID not set; exit 1; else echo YOTI_SCENARIO_ID is $YOTI_SCENARIO_ID ; fi
 RUN if [ "$YOTI_CLIENT_SDK_ID" = "yourClientSdkId" ] ; then echo YOTI_CLIENT_SDK_ID not set; exit 1; else echo YOTI_CLIENT_SDK_ID is $YOTI_CLIENT_SDK_ID ; fi
 RUN if [ "$YOTI_KEY_FILE_PATH" = "yourKeyFilePath" ] ; then echo YOTI_KEY_FILE_PATH not set; exit 1; else echo YOTI_KEY_FILE_PATH is $YOTI_KEY_FILE_PATH ; fi
-ADD . /code
-WORKDIR /code
+ADD . /yoti-sdk
+WORKDIR /yoti-sdk/examples/yoti_example_flask/
+RUN pip install --no-cache-dir -r /yoti-sdk/requirements.txt && pip install /yoti-sdk
 RUN pip install --no-cache-dir -r requirements.txt
 CMD ["python", "app.py"]

--- a/examples/yoti_example_flask/docker-compose.yml
+++ b/examples/yoti_example_flask/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.4'
 services:
   web:
     build:
-      context: ./
+      context: ../../
+      dockerfile: examples/yoti_example_flask/Dockerfile
       args:
         YOTI_SCENARIO_ID: "${YOTI_SCENARIO_ID}"
         YOTI_CLIENT_SDK_ID: "${YOTI_CLIENT_SDK_ID}"


### PR DESCRIPTION
### Changed
 * Removes Yoti as a requirement from requirements.txt
 * Modify the Dockerfiles for flask and Django so that the Yoti SDK is sent as part of
the build context. Because of the change in build context the dockerfile
has been moved to more readily indicate the directory that should be
sent. Readme instructions have been updated accordingly as well.
