### PR TITLE
SDK-891: Ensure UTC Dates are used

### DIFF
--- a/yoti_python_sdk/activity_details.py
+++ b/yoti_python_sdk/activity_details.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytz
+
 from datetime import datetime
 
 from yoti_python_sdk.profile import Profile, ApplicationProfile
@@ -24,6 +26,7 @@ class ActivityDetails:
 
         if timestamp is not None:
             self.timestamp = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+            self.timestamp = self.timestamp.replace(tzinfo=pytz.utc)
 
     @property
     def remember_me_id(self):

--- a/yoti_python_sdk/anchor.py
+++ b/yoti_python_sdk/anchor.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+import pytz
 import OpenSSL
 import asn1
 import yoti_python_sdk.protobuf.common_public_api.SignedTimestamp_pb2 as compubapi
@@ -181,7 +182,7 @@ class Anchor:
 
         try:
             signed_timestamp_parsed = datetime.datetime.fromtimestamp(
-                signed_timestamp_object.timestamp / float(1000000)
+                signed_timestamp_object.timestamp / float(1000000), tz=pytz.utc
             )
         except OSError:
             print(

--- a/yoti_python_sdk/tests/test_activity_details.py
+++ b/yoti_python_sdk/tests/test_activity_details.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytz
+
 from datetime import datetime
 
 from yoti_python_sdk import config
@@ -36,7 +38,9 @@ def test_failure_receipt_handled(failure_receipt, remember_me_id):
 
     assert activity_details.remember_me_id == remember_me_id
     assert activity_details.outcome == "FAILURE"
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(
+        2016, 11, 14, 11, 35, 33, tzinfo=pytz.utc
+    )
 
 
 def test_missing_values_handled(no_values_receipt):

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
+import pytz
 import logging
-import time
+import yoti_python_sdk
+
 from datetime import datetime
 
-from yoti_python_sdk.protobuf.attribute_public_api import Attribute_pb2
-
-import yoti_python_sdk
 from yoti_python_sdk import config
 from yoti_python_sdk.anchor import Anchor
 from yoti_python_sdk.tests import anchor_fixture_parser
-
-
-def get_utc_offset():
-    utc_offset = int(time.timezone / 60 / 60)
-
-    if time.daylight:
-        utc_offset = utc_offset - time.daylight
-
-    return utc_offset
+from yoti_python_sdk.protobuf.attribute_public_api import Attribute_pb2
 
 
 def test_parse_anchor_non_critical_only():
@@ -36,7 +27,7 @@ def test_parse_anchors_driving_license():
         "46131813624213904216516051554755262812"
     )
     assert parsed_anchor.signed_timestamp == datetime(
-        2018, 4, 11, 12 - get_utc_offset(), 13, 3, 923537
+        2018, 4, 11, 12, 13, 3, 923537, tzinfo=pytz.utc
     )
 
 
@@ -50,7 +41,7 @@ def test_parse_anchors_passport():
         "277870515583559162487099305254898397834"
     )
     assert parsed_anchor.signed_timestamp == datetime(
-        2018, 4, 12, 13 - get_utc_offset(), 14, 32, 835537
+        2018, 4, 12, 13, 14, 32, 835537, tzinfo=pytz.utc
     )
 
 
@@ -64,7 +55,7 @@ def test_parse_yoti_admin():
         "256616937783084706710155170893983549581"
     )
     assert parsed_anchor.signed_timestamp == datetime(
-        2018, 4, 11, 12 - get_utc_offset(), 13, 4, 95238
+        2018, 4, 11, 12, 13, 4, 95238, tzinfo=pytz.utc
     )
 
 
@@ -103,7 +94,7 @@ def test_error_parsing_anchor_certificate_carries_on_parsing():
         "46131813624213904216516051554755262812"
     )
     assert parsed_anchor.signed_timestamp == datetime(
-        2018, 4, 11, 12 - get_utc_offset(), 13, 3, 923537
+        2018, 4, 11, 12, 13, 3, 923537, tzinfo=pytz.utc
     )
 
 
@@ -118,7 +109,7 @@ def test_processing_unknown_anchor_data():
         (anchor.value, anchor.anchor_type, anchor.sub_type) for anchor in anchors
     ]
 
-    expected_timestamp = datetime(2019, 3, 5, 10, 45, 11, 840037)
+    expected_timestamp = datetime(2019, 3, 5, 10, 45, 11, 840037, tzinfo=pytz.utc)
     actual_timestamp = anchors[0].signed_timestamp
 
     assert expected_timestamp == actual_timestamp

--- a/yoti_python_sdk/tests/test_client.py
+++ b/yoti_python_sdk/tests/test_client.py
@@ -36,6 +36,7 @@ from yoti_python_sdk.config import (
     X_YOTI_SDK_VERSION,
 )
 
+import pytz
 import pytest
 import yoti_python_sdk
 
@@ -168,7 +169,9 @@ def test_requesting_activity_details_with_correct_data(
         activity_details.receipt_id
         == "9HNJDX5bEIN5TqBm0OGzVIc1LaAmbzfx6eIrwNdwpHvKeQmgPujyogC+r7hJCVPl"
     )
-    assert activity_details.timestamp == datetime(2016, 7, 19, 8, 55, 38)
+    assert activity_details.timestamp == datetime(
+        2016, 7, 19, 8, 55, 38, tzinfo=pytz.utc
+    )
 
     selfie_profile = activity_details.profile.selfie.value
     assert isinstance(selfie_profile, basestring)
@@ -205,7 +208,9 @@ def test_requesting_activity_details_with_null_profile(
         activity_details.receipt_id
         == "Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN"
     )
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(
+        2016, 11, 14, 11, 35, 33, tzinfo=pytz.utc
+    )
     assert isinstance(activity_details, ActivityDetails)
 
 
@@ -230,7 +235,9 @@ def test_requesting_activity_details_with_empty_profile(
         activity_details.receipt_id
         == "Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN"
     )
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(
+        2016, 11, 14, 11, 35, 33, tzinfo=pytz.utc
+    )
     assert isinstance(activity_details, ActivityDetails)
 
 
@@ -255,7 +262,9 @@ def test_requesting_activity_details_with_missing_profile(
         activity_details.receipt_id
         == "Eq3+P8qjAlxr4d2mXKCUvzKdJTchI53ghwYPZXyA/cF5T+m/HCP1bK5LOmudZASN"
     )
-    assert activity_details.timestamp == datetime(2016, 11, 14, 11, 35, 33)
+    assert activity_details.timestamp == datetime(
+        2016, 11, 14, 11, 35, 33, tzinfo=pytz.utc
+    )
     assert isinstance(activity_details, ActivityDetails)
 
 


### PR DESCRIPTION
## Changed

* `ActivityDetails.timestamp` and `Anchor.signed_timestamp` are now always returned as a UTC timestamp.