### PR TITLE
SDK-1293: Refactor anchor parsing

### DIFF
--- a/yoti_python_sandbox/anchor.py
+++ b/yoti_python_sandbox/anchor.py
@@ -1,10 +1,10 @@
-from yoti_python_sdk.anchor import UNKNOWN_ANCHOR_TYPE
+from yoti_python_sdk.config import ANCHOR_UNKNOWN
 
 
 class SandboxAnchor(object):
     def __init__(self, anchor_type=None, sub_type=None, value=None, timestamp=None):
         if anchor_type is None:
-            anchor_type = UNKNOWN_ANCHOR_TYPE
+            anchor_type = ANCHOR_UNKNOWN
         if sub_type is None:
             sub_type = ""
         if value is None:

--- a/yoti_python_sdk/anchor.py
+++ b/yoti_python_sdk/anchor.py
@@ -1,19 +1,9 @@
-import datetime
-import logging
-
-import pytz
-import OpenSSL
-import asn1
-import yoti_python_sdk.protobuf.common_public_api.SignedTimestamp_pb2 as compubapi
-from OpenSSL import crypto
-
 from yoti_python_sdk import config
 
 UNKNOWN_EXTENSION = ""
 SOURCE_EXTENSION = "1.3.6.1.4.1.47127.1.1.1"
 VERIFIER_EXTENSION = "1.3.6.1.4.1.47127.1.1.2"
 
-UNKNOWN_ANCHOR_TYPE = "UNKNOWN"
 UNKNOWN_ANCHOR_VALUE = ""
 
 
@@ -33,7 +23,7 @@ class Anchor:
             value = ""
 
         if anchor_type is None:
-            anchor_type = UNKNOWN_ANCHOR_TYPE
+            anchor_type = config.ANCHOR_UNKNOWN
 
         self.__anchor_type = anchor_type
         self.__sub_type = sub_type
@@ -52,114 +42,6 @@ class Anchor:
             self.idx = 0
             raise StopIteration
 
-    next = __next__  # python2.x compatibility.
-
-    @staticmethod
-    def parse_anchors(anchors):
-        if anchors is None:
-            return None
-
-        parsed_anchors = []
-        for anc in anchors:
-            if hasattr(anc, "origin_server_certs"):
-                anchor_type = UNKNOWN_ANCHOR_TYPE
-                try:
-                    origin_server_certs_list = list(anc.origin_server_certs)
-                    origin_server_certs_item = origin_server_certs_list[0]
-
-                    crypto_cert = crypto.load_certificate(
-                        OpenSSL.crypto.FILETYPE_ASN1, origin_server_certs_item
-                    ).to_cryptography()
-
-                except Exception as exc:
-                    if logging.getLogger().propagate:
-                        logging.warning(
-                            "Error loading anchor certificate, exception: {0} - {1}".format(
-                                type(exc).__name__, exc
-                            )
-                        )
-                    continue
-
-                has_found_anchor = False
-                for i in range(len(crypto_cert.extensions)):
-                    anchor_type = UNKNOWN_ANCHOR_TYPE
-
-                    try:
-                        extensions = crypto_cert.extensions[i]
-                        if hasattr(extensions, "oid"):
-                            oid = extensions.oid
-                            if hasattr(oid, "dotted_string"):
-                                if oid.dotted_string == SOURCE_EXTENSION:
-                                    anchor_type = config.ANCHOR_SOURCE
-                                elif oid.dotted_string == VERIFIER_EXTENSION:
-                                    anchor_type = config.ANCHOR_VERIFIER
-
-                                if anchor_type != UNKNOWN_ANCHOR_TYPE:
-                                    has_found_anchor = True
-                                    parsed_anchors = Anchor.get_values_from_extensions(
-                                        anc,
-                                        anchor_type,
-                                        extensions,
-                                        crypto_cert,
-                                        parsed_anchors,
-                                    )
-
-                    except Exception as exc:
-                        if logging.getLogger().propagate:
-                            logging.warning(
-                                "Error parsing anchor certificate extension, exception: {0} - {1}".format(
-                                    type(exc).__name__, exc
-                                )
-                            )
-                        continue
-
-                if not has_found_anchor:
-                    parsed_anchors.append(
-                        Anchor(
-                            UNKNOWN_ANCHOR_TYPE,
-                            anc.sub_type,
-                            UNKNOWN_ANCHOR_VALUE,
-                            anc.signed_time_stamp,
-                            crypto_cert,
-                        )
-                    )
-
-        return parsed_anchors
-
-    @staticmethod
-    def get_values_from_extensions(
-        anc, anchor_type, extensions, crypto_cert, parsed_anchors
-    ):
-        if hasattr(extensions, "value") and anchor_type != UNKNOWN_ANCHOR_TYPE:
-            extension_value = ""
-            if hasattr(extensions.value, "value"):
-                extension_value = Anchor.decode_asn1_value(extensions.value.value)
-            parsed_anchors.append(
-                Anchor(
-                    anchor_type,
-                    anc.sub_type,
-                    extension_value,
-                    anc.signed_time_stamp,
-                    crypto_cert,
-                )
-            )
-
-        return parsed_anchors
-
-    @staticmethod
-    def decode_asn1_value(value_to_decode):
-        extension_value_asn1 = value_to_decode
-        decoder = asn1.Decoder()
-
-        decoder.start(extension_value_asn1)
-        tag, once_decoded_value = decoder.read()
-
-        decoder.start(once_decoded_value)
-        tag, twice_decoded_value = decoder.read()
-
-        utf8_value = twice_decoded_value.decode("utf-8")
-        return utf8_value
-
     @property
     def anchor_type(self):
         return self.__anchor_type
@@ -174,25 +56,7 @@ class Anchor:
 
     @property
     def signed_timestamp(self):
-        if self.__signed_timestamp is None:
-            return None
-
-        signed_timestamp_object = compubapi.SignedTimestamp()
-        signed_timestamp_object.MergeFromString(self.__signed_timestamp)
-
-        try:
-            signed_timestamp_parsed = datetime.datetime.fromtimestamp(
-                signed_timestamp_object.timestamp / float(1000000), tz=pytz.utc
-            )
-        except OSError:
-            print(
-                "Unable to parse timestamp from integer: '{0}'".format(
-                    signed_timestamp_object.timestamp
-                )
-            )
-            return ""
-
-        return signed_timestamp_parsed
+        return self.__signed_timestamp
 
     @property
     def origin_server_certs(self):

--- a/yoti_python_sdk/anchor_parser.py
+++ b/yoti_python_sdk/anchor_parser.py
@@ -1,0 +1,153 @@
+import datetime
+import logging
+
+import pytz
+import OpenSSL
+import asn1
+from OpenSSL import crypto
+
+from yoti_python_sdk import config
+from yoti_python_sdk.protobuf.common_public_api.SignedTimestamp_pb2 import (
+    SignedTimestamp,
+)
+from yoti_python_sdk.anchor import (
+    Anchor,
+    SOURCE_EXTENSION,
+    VERIFIER_EXTENSION,
+    UNKNOWN_ANCHOR_VALUE,
+)
+
+
+def parse_anchors(anchors):
+    """
+    Parse the supplied anchors
+    :return: Anchor[]
+    """
+    if anchors is None:
+        return None
+
+    parsed_anchors = []
+    for anc in anchors:
+        crypto_cert = extract_crypto_cert(anc)
+        if crypto_cert is None:
+            continue
+
+        has_found_anchor = False
+        for i in range(len(crypto_cert.extensions)):
+            extension = crypto_cert.extensions[i]
+            anchor_type = extract_anchor_type(extension)
+
+            if (
+                anchor_type == config.ANCHOR_SOURCE
+                or anchor_type == config.ANCHOR_VERIFIER
+            ):
+                parsed_anchor = get_values_from_extensions(
+                    anc, anchor_type, extension, crypto_cert
+                )
+                if parsed_anchor is not None:
+                    has_found_anchor = True
+                    parsed_anchors.append(parsed_anchor)
+
+        if not has_found_anchor:
+            parsed_anchors.append(
+                Anchor(
+                    config.ANCHOR_UNKNOWN,
+                    anc.sub_type,
+                    UNKNOWN_ANCHOR_VALUE,
+                    parse_signed_timestamp(anc.signed_time_stamp),
+                    crypto_cert,
+                )
+            )
+
+    return parsed_anchors
+
+
+def extract_anchor_type(extension):
+    try:
+        if hasattr(extension, "oid"):
+            oid = extension.oid
+            if hasattr(oid, "dotted_string"):
+                if oid.dotted_string == SOURCE_EXTENSION:
+                    return config.ANCHOR_SOURCE
+                elif oid.dotted_string == VERIFIER_EXTENSION:
+                    return config.ANCHOR_VERIFIER
+    except Exception as exc:
+        if logging.getLogger().propagate:
+            logging.warning(
+                "Error parsing anchor certificate extension, exception: {0} - {1}".format(
+                    type(exc).__name__, exc
+                )
+            )
+
+    return config.ANCHOR_UNKNOWN
+
+
+def extract_crypto_cert(anchor):
+    if hasattr(anchor, "origin_server_certs"):
+        try:
+            origin_server_certs_list = list(anchor.origin_server_certs)
+            origin_server_certs_item = origin_server_certs_list[0]
+
+            crypto_cert = crypto.load_certificate(
+                OpenSSL.crypto.FILETYPE_ASN1, origin_server_certs_item
+            ).to_cryptography()
+
+            return crypto_cert
+        except Exception as exc:
+            if logging.getLogger().propagate:
+                logging.warning(
+                    "Error loading anchor certificate, exception: {0} - {1}".format(
+                        type(exc).__name__, exc
+                    )
+                )
+
+    return None
+
+
+def get_values_from_extensions(anc, anchor_type, extensions, crypto_cert):
+    if hasattr(extensions, "value") and anchor_type != config.ANCHOR_UNKNOWN:
+        extension_value = ""
+        if hasattr(extensions.value, "value"):
+            extension_value = decode_asn1_value(extensions.value.value)
+        return Anchor(
+            anchor_type,
+            anc.sub_type,
+            extension_value,
+            parse_signed_timestamp(anc.signed_time_stamp),
+            crypto_cert,
+        )
+
+    return None
+
+
+def decode_asn1_value(value_to_decode):
+    extension_value_asn1 = value_to_decode
+    decoder = asn1.Decoder()
+
+    decoder.start(extension_value_asn1)
+    tag, once_decoded_value = decoder.read()
+
+    decoder.start(once_decoded_value)
+    tag, twice_decoded_value = decoder.read()
+
+    utf8_value = twice_decoded_value.decode("utf-8")
+    return utf8_value
+
+
+def parse_signed_timestamp(timestamp):
+    signed_timestamp_object = SignedTimestamp()
+    signed_timestamp_object.MergeFromString(timestamp)
+
+    try:
+        signed_timestamp_parsed = datetime.datetime.fromtimestamp(
+            signed_timestamp_object.timestamp / float(1000000), tz=pytz.utc
+        )
+    except OSError:
+        print(
+            "Unable to parse timestamp from integer: '{0}'".format(
+                signed_timestamp_object.timestamp
+            )
+        )
+        return None
+
+    return signed_timestamp_parsed

--- a/yoti_python_sdk/config.py
+++ b/yoti_python_sdk/config.py
@@ -20,8 +20,11 @@ ATTRIBUTE_APPLICATION_NAME = "application_name"
 ATTRIBUTE_APPLICATION_LOGO = "application_logo"
 ATTRIBUTE_APPLICATION_URL = "application_url"
 ATTRIBUTE_APPLICATION_RECEIPT_BGCOLOR = "application_receipt_bgcolor"
+
 ANCHOR_SOURCE = "SOURCE"
 ANCHOR_VERIFIER = "VERIFIER"
+ANCHOR_UNKNOWN = "UNKNOWN"
+
 KEY_AGE_VERIFIED = "is_age_verified"
 KEY_BASE64_SELFIE = "base64_selfie_uri"
 KEY_FORMATTED_ADDRESS = "formatted_address"

--- a/yoti_python_sdk/profile.py
+++ b/yoti_python_sdk/profile.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from yoti_python_sdk import attribute_parser, config, multivalue, document_details
-from yoti_python_sdk.anchor import Anchor
+from yoti_python_sdk import (
+    attribute_parser,
+    anchor_parser,
+    config,
+    multivalue,
+    document_details,
+)
 from yoti_python_sdk.attribute import Attribute
 from yoti_python_sdk.image import Image
 from yoti_python_sdk.age_verification import AgeVerification
@@ -30,7 +35,7 @@ class BaseProfile(object):
                     if field.name == config.ATTRIBUTE_DOCUMENT_DETAILS:
                         value = document_details.DocumentDetails(value)
 
-                    anchors = Anchor().parse_anchors(field.anchors)
+                    anchors = anchor_parser.parse_anchors(field.anchors)
 
                     self.attributes[field.name] = Attribute(field.name, value, anchors)
 

--- a/yoti_python_sdk/tests/anchor_fixture_parser.py
+++ b/yoti_python_sdk/tests/anchor_fixture_parser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from os.path import abspath, dirname, join
 
-from yoti_python_sdk import anchor
+from yoti_python_sdk import anchor_parser
 from yoti_python_sdk.protobuf import protobuf
 from yoti_python_sdk.tests import file_helper
 
@@ -24,24 +24,22 @@ def get_anchor_from_base64_text(file_path):
 
 
 def get_parsed_driving_license_anchor():
-    return anchor.Anchor().parse_anchors(
+    return anchor_parser.parse_anchors(
         get_anchor_from_base64_text(ANCHOR_DRIVING_LICENSE)
     )[0]
 
 
 def get_parsed_anchor_critical_last():
-    return anchor.Anchor().parse_anchors(
+    return anchor_parser.parse_anchors(
         get_anchor_from_base64_text(ANCHOR_CRITICAL_LAST)
     )
 
 
 def get_parsed_passport_anchor():
-    return anchor.Anchor().parse_anchors(get_anchor_from_base64_text(ANCHOR_PASSPORT))[
-        0
-    ]
+    return anchor_parser.parse_anchors(get_anchor_from_base64_text(ANCHOR_PASSPORT))[0]
 
 
 def get_parsed_yoti_admin_anchor():
-    return anchor.Anchor().parse_anchors(
-        get_anchor_from_base64_text(ANCHOR_YOTI_ADMIN)
-    )[0]
+    return anchor_parser.parse_anchors(get_anchor_from_base64_text(ANCHOR_YOTI_ADMIN))[
+        0
+    ]

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -5,8 +5,7 @@ import yoti_python_sdk
 
 from datetime import datetime
 
-from yoti_python_sdk import config
-from yoti_python_sdk.anchor import Anchor
+from yoti_python_sdk import config, anchor_parser
 from yoti_python_sdk.tests import anchor_fixture_parser
 from yoti_python_sdk.protobuf.attribute_public_api import Attribute_pb2
 
@@ -81,7 +80,7 @@ def test_error_parsing_anchor_certificate_carries_on_parsing():
     logger = logging.getLogger()
     logger.propagate = False
 
-    parsed_anchors = Anchor.parse_anchors(anchors)
+    parsed_anchors = anchor_parser.parse_anchors(anchors)
     logger.propagate = True
 
     assert len(parsed_anchors) == 1
@@ -102,7 +101,7 @@ def test_processing_unknown_anchor_data():
     unknown_anchor_data = anchor_fixture_parser.get_anchor_from_base64_text(
         anchor_fixture_parser.ANCHOR_UNKNOWN_ANCHOR
     )
-    anchors = Anchor.parse_anchors(unknown_anchor_data)
+    anchors = anchor_parser.parse_anchors(unknown_anchor_data)
 
     assert len(anchors) == 1
     assert ("", "UNKNOWN", "TEST UNKNOWN SUB TYPE") in [

--- a/yoti_python_sdk/tests/test_client.py
+++ b/yoti_python_sdk/tests/test_client.py
@@ -153,13 +153,7 @@ def test_creating_client_instance_with_valid_key_file_env_but_invalid_key_file_a
 @mock.patch("time.time", side_effect=mocked_timestamp)
 @mock.patch("uuid.uuid4", side_effect=mocked_uuid4)
 def test_requesting_activity_details_with_correct_data(
-    mock_uuid4,
-    mock_time,
-    mock_get,
-    client,
-    expected_activity_details_url,
-    expected_get_headers,
-    encrypted_request_token,
+    mock_uuid4, mock_time, mock_get, client, encrypted_request_token
 ):
     activity_details = client.get_activity_details(encrypted_request_token)
 


### PR DESCRIPTION
## Added

* `anchor_parser.py`
  * This is now where all parsing of anchor protobufs is done, separating the responsibility away from the `Anchor` object which is now just a model.
  * This has also reduced the cognitive complexity of the anchor parsing

## Changed

* Moved unknown anchor type into `yoti_python_sdk.config` as this is where source and verifier also lives