### PR TITLE
SDK-1296: Update Profile to store selfie as an Image object

### DIFF
--- a/examples/yoti_example_django/yoti_example/views.py
+++ b/examples/yoti_example_django/yoti_example/views.py
@@ -94,8 +94,8 @@ class AuthView(TemplateView):
         profile_dict = vars(profile)
 
         context = profile_dict.get("attributes")
-        context["base64_selfie_uri"] = getattr(activity_details, "base64_selfie_uri")
-        context["user_id"] = getattr(activity_details, "user_id")
+        context["base64_selfie_uri"] = profile.selfie.value.base64_content()
+        context["user_id"] = activity_details.remember_me_id
         context["parent_remember_me_id"] = getattr(
             activity_details, "parent_remember_me_id"
         )
@@ -117,7 +117,7 @@ class AuthView(TemplateView):
 
         selfie = context.get("selfie")
         if selfie is not None:
-            self.save_image(selfie.value)
+            self.save_image(selfie.value.data)
         return self.render_to_response(context)
 
     @staticmethod

--- a/examples/yoti_example_django/yoti_example/views.py
+++ b/examples/yoti_example_django/yoti_example/views.py
@@ -115,9 +115,6 @@ class AuthView(TemplateView):
                 "verifiers": age_verified.attribute.verifiers,
             }
 
-        selfie = context.get("selfie")
-        if selfie is not None:
-            self.save_image(selfie.value.data)
         return self.render_to_response(context)
 
     @staticmethod

--- a/examples/yoti_example_flask/app.py
+++ b/examples/yoti_example_flask/app.py
@@ -110,9 +110,6 @@ def auth():
             "verifiers": age_verified.attribute.verifiers,
         }
 
-    selfie = context.get("selfie")
-    if selfie is not None:
-        save_image(selfie.value.data)
     return render_template("profile.html", **context)
 
 

--- a/examples/yoti_example_flask/app.py
+++ b/examples/yoti_example_flask/app.py
@@ -89,7 +89,7 @@ def auth():
     profile_dict = vars(profile)
 
     context = profile_dict.get("attributes")
-    context["base64_selfie_uri"] = getattr(activity_details, "base64_selfie_uri")
+    context["base64_selfie_uri"] = profile.selfie.value.base64_content()
     context["remember_me_id"] = getattr(activity_details, "remember_me_id")
     context["parent_remember_me_id"] = getattr(
         activity_details, "parent_remember_me_id"
@@ -112,7 +112,7 @@ def auth():
 
     selfie = context.get("selfie")
     if selfie is not None:
-        save_image(selfie.value)
+        save_image(selfie.value.data)
     return render_template("profile.html", **context)
 
 

--- a/yoti_python_sdk/profile.py
+++ b/yoti_python_sdk/profile.py
@@ -25,10 +25,8 @@ class BaseProfile(object):
                         field.value, field.content_type
                     )
 
-                    # this will be removed in v3.0.0, so selfie also returns an Image object
                     if field.content_type in Image.allowed_types():
-                        if field.name == config.ATTRIBUTE_SELFIE:
-                            value = field.value
+                        value = Image(field.value, field.content_type)
 
                     if field.name == config.ATTRIBUTE_DOCUMENT_IMAGES:
                         value = multivalue.filter_values(value, Image)

--- a/yoti_python_sdk/tests/test_client.py
+++ b/yoti_python_sdk/tests/test_client.py
@@ -8,12 +8,12 @@ except ImportError:
 
 from datetime import datetime
 from os import environ
-from past.builtins import basestring
 
 from yoti_python_sdk import config
 from yoti_python_sdk import YOTI_API_ENDPOINT
 from yoti_python_sdk import Client
 from yoti_python_sdk import aml
+from yoti_python_sdk.image import Image
 from yoti_python_sdk.client import NO_KEY_FILE_SPECIFIED_ERROR
 from yoti_python_sdk.activity_details import ActivityDetails
 from yoti_python_sdk.tests.conftest import YOTI_CLIENT_SDK_ID, PEM_FILE_PATH
@@ -168,7 +168,7 @@ def test_requesting_activity_details_with_correct_data(
     )
 
     selfie_profile = activity_details.profile.selfie.value
-    assert isinstance(selfie_profile, basestring)
+    assert isinstance(selfie_profile, Image)
     assert (
         activity_details.profile.get_attribute(config.ATTRIBUTE_SELFIE)
         == activity_details.profile.selfie


### PR DESCRIPTION
## Changed

* `Profile` now stores all image attributes (PNG or JPEG currently) as an Image object rather than just the raw bytes
* Example projects have been updated to reflect this