### PR TITLE
SDK-1165: Refactor endpoint module

### DIFF
--- a/yoti_python_sdk/client.py
+++ b/yoti_python_sdk/client.py
@@ -128,9 +128,7 @@ class Client(object):
         decrypted_token = self.__crypto.decrypt_token(encrypted_request_token).decode(
             "utf-8"
         )
-        path = self.__endpoint.get_activity_details_request_path(
-            decrypted_token, no_params=True
-        )
+        path = self.__endpoint.get_activity_details_request_path(decrypted_token)
 
         signed_request = (
             SignedRequest.builder()
@@ -155,7 +153,7 @@ class Client(object):
     def __make_aml_check_request(self, aml_profile):
         aml_profile_json = json.dumps(aml_profile.__dict__, sort_keys=True)
         aml_profile_bytes = aml_profile_json.encode()
-        path = self.__endpoint.get_aml_request_url(no_params=True)
+        path = self.__endpoint.get_aml_request_url()
 
         signed_request = (
             SignedRequest.builder()

--- a/yoti_python_sdk/dynamic_sharing_service/share_url.py
+++ b/yoti_python_sdk/dynamic_sharing_service/share_url.py
@@ -19,7 +19,7 @@ SHARE_URL_ERRORS.update(client.DEFAULT_HTTP_CLIENT_ERRORS)
 def create_share_url(yoti_client, dynamic_scenario):
     http_method = "POST"
     payload = json.dumps(dynamic_scenario, sort_keys=True).encode()
-    endpoint = yoti_client.endpoints.get_dynamic_share_request_url(no_params=True)
+    endpoint = yoti_client.endpoints.get_dynamic_share_request_url()
     response = yoti_client.make_request(http_method, endpoint, payload)
 
     client.Client.http_error_handler(response, SHARE_URL_ERRORS)

--- a/yoti_python_sdk/endpoint.py
+++ b/yoti_python_sdk/endpoint.py
@@ -1,32 +1,14 @@
-from yoti_python_sdk.utils import create_timestamp, create_nonce
-
-
 class Endpoint(object):
     def __init__(self, sdk_id):
         self.sdk_id = sdk_id
 
-    def get_activity_details_request_path(
-        self, decrypted_request_token, no_params=False
-    ):
-        if no_params:
-            return "/profile/{0}".format(decrypted_request_token)
+    @staticmethod
+    def get_activity_details_request_path(decrypted_request_token):
+        return "/profile/{0}".format(decrypted_request_token)
 
-        return "/profile/{0}?nonce={1}&timestamp={2}&appId={3}".format(
-            decrypted_request_token, create_nonce(), create_timestamp(), self.sdk_id
-        )
+    @staticmethod
+    def get_aml_request_url():
+        return "/aml-check"
 
-    def get_aml_request_url(self, no_params=False):
-        if no_params:
-            return "/aml-check"
-
-        return "/aml-check?appId={0}&timestamp={1}&nonce={2}".format(
-            self.sdk_id, create_timestamp(), create_nonce()
-        )
-
-    def get_dynamic_share_request_url(self, no_params=False):
-        if no_params:
-            return "/qrcodes/apps/{appid}".format(appid=self.sdk_id)
-
-        return "/qrcodes/apps/{appid}?nonce={nonce}&timestamp={timestamp}".format(
-            appid=self.sdk_id, nonce=create_nonce(), timestamp=create_timestamp()
-        )
+    def get_dynamic_share_request_url(self):
+        return "/qrcodes/apps/{appid}".format(appid=self.sdk_id)


### PR DESCRIPTION
## Changed

* The `endpoint` module was changed when the signed request builder was introduced to allow users to get endpoints without query parameters, using an optional boolean flag as a parameter to make it backwards compatible
* In the major, everything internally should be using the signed request builder, which no longer requires endpoints to have query parameters added