### PR TITLE
SDK-916: Introduce immutability to all attributes and anchors

### DIFF
--- a/yoti_python_sdk/anchor_parser.py
+++ b/yoti_python_sdk/anchor_parser.py
@@ -21,7 +21,8 @@ from yoti_python_sdk.anchor import (
 def parse_anchors(anchors):
     """
     Parse the supplied anchors
-    :return: Anchor[]
+
+    :return: tuple(Anchor, ...)
     """
     if anchors is None:
         return None
@@ -59,7 +60,7 @@ def parse_anchors(anchors):
                 )
             )
 
-    return parsed_anchors
+    return tuple(parsed_anchors)
 
 
 def extract_anchor_type(extension):

--- a/yoti_python_sdk/attribute.py
+++ b/yoti_python_sdk/attribute.py
@@ -8,7 +8,7 @@ class Attribute:
         if value is None:
             value = ""
         if anchors is None:
-            anchors = {}
+            anchors = tuple()
         self.__name = name
         self.__value = value
         self.__anchors = anchors
@@ -27,12 +27,12 @@ class Attribute:
 
     @property
     def sources(self):
-        return list(
+        return tuple(
             filter(lambda a: a.anchor_type == config.ANCHOR_SOURCE, self.__anchors)
         )
 
     @property
     def verifiers(self):
-        return list(
+        return tuple(
             filter(lambda a: a.anchor_type == config.ANCHOR_VERIFIER, self.__anchors)
         )

--- a/yoti_python_sdk/attribute_parser.py
+++ b/yoti_python_sdk/attribute_parser.py
@@ -30,7 +30,7 @@ def value_based_on_content_type(value, content_type=None):
         int_value = int(string_value)
         return int_value
     elif content_type == Protobuf.CT_MULTI_VALUE:
-        return tuple(multivalue.parse(value))
+        return multivalue.parse(value)
 
     if logging.getLogger().propagate:
         logging.warning(

--- a/yoti_python_sdk/multivalue.py
+++ b/yoti_python_sdk/multivalue.py
@@ -18,7 +18,7 @@ def parse(multi_value_bytes):
             )
         )
 
-    return multi_value_list
+    return tuple(multi_value_list)
 
 
 def filter_values(values, type_to_filter):

--- a/yoti_python_sdk/tests/test_anchor.py
+++ b/yoti_python_sdk/tests/test_anchor.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytz
 import logging
+import pytest
 import yoti_python_sdk
 
 from datetime import datetime
@@ -116,3 +117,22 @@ def test_processing_unknown_anchor_data():
     assert "document-registration-server" in [
         a.value for a in anchors[0].origin_server_certs.issuer
     ]
+
+
+def test_anchor_tuple_is_immutable():
+    parsed_anchor = anchor_fixture_parser.get_parsed_anchor_critical_last()
+
+    with pytest.raises(TypeError) as ex:
+        parsed_anchor[0] = "someOtherValue"
+
+    assert "does not support item assignment" in str(ex.value)
+
+
+def test_anchor_tuple_objects_are_immutable():
+    parsed_anchor = anchor_fixture_parser.get_parsed_anchor_critical_last()
+
+    with pytest.raises(AttributeError) as ex:
+        anchor = parsed_anchor[0]
+        anchor.value = "someOtherValue"
+
+    assert "can't set attribute" in str(ex.value)

--- a/yoti_python_sdk/tests/test_attribute.py
+++ b/yoti_python_sdk/tests/test_attribute.py
@@ -1,3 +1,4 @@
+import pytest
 import yoti_python_sdk.attribute
 
 from yoti_python_sdk import config
@@ -8,9 +9,9 @@ VALUE = "value"
 
 
 def test_attribute_get_values():
-    parsed_anchors = []
+    parsed_anchors = tuple()
 
-    attribute = yoti_python_sdk.attribute.Attribute(NAME, VALUE, parsed_anchors)
+    attribute = yoti_python_sdk.attribute.Attribute(NAME, VALUE, tuple())
 
     assert attribute.name == NAME
     assert attribute.value == VALUE
@@ -39,4 +40,31 @@ def create_source_and_verifier_anchors():
     passport_anchor = anchor_fixture_parser.get_parsed_passport_anchor()  # source
     yoti_admin_anchor = anchor_fixture_parser.get_parsed_yoti_admin_anchor()  # verifier
 
-    return [passport_anchor, yoti_admin_anchor]
+    return passport_anchor, yoti_admin_anchor
+
+
+def test_attribute_name_is_immutable():
+    attribute = yoti_python_sdk.attribute.Attribute(NAME, VALUE, tuple())
+
+    with pytest.raises(AttributeError) as ex:
+        attribute.name = "someOtherName"
+
+    assert "can't set attribute" in str(ex.value)
+
+
+def test_attribute_value_is_immutable():
+    attribute = yoti_python_sdk.attribute.Attribute(NAME, VALUE, tuple())
+
+    with pytest.raises(AttributeError) as ex:
+        attribute.value = "someOtherValue"
+
+    assert "can't set attribute" in str(ex.value)
+
+
+def test_attribute_anchors_is_immutable():
+    attribute = yoti_python_sdk.attribute.Attribute(NAME, VALUE, tuple())
+
+    with pytest.raises(AttributeError) as ex:
+        attribute.anchors = "someFirstAnchor", "someSecondAnchor"
+
+    assert "can't set attribute" in str(ex.value)


### PR DESCRIPTION
## Changed

* In the previous major version, multivalue attribute values were introduced that were returned as a tuple rather than a list.
* In python, tuples are immutable if the objects inside are also immutable.  All of the models that we use hide the internal representation of attributes on an object, and use @property methods therefore making our models also immutable.
* All of the parsers (attribute and anchor) have been updated to return tuples instead of lists.  This still allows users to access data in exactly the same way as before, but ensures immutability of data returned from a share.