### PR TITLE
SDK-1286: Document Details private properties

### DIFF
--- a/yoti_python_sdk/document_details.py
+++ b/yoti_python_sdk/document_details.py
@@ -8,6 +8,10 @@ class DocumentDetails(object):
     VALIDATION_REGEX = re.compile("^[A-Za-z_]* [A-Za-z]{3} [A-Za-z0-9]{1}.*$")
 
     def __init__(self, data):
+        # Non-required attributes default to None
+        self.__expiration_date = None
+        self.__issuing_authority = None
+
         self.__validate_data(data)
         self.__parse_data(data)
 
@@ -25,11 +29,11 @@ class DocumentDetails(object):
 
     @property
     def expiration_date(self):
-        return self.__dict__.get("_DocumentDetails__expiration_date", None)
+        return self.__expiration_date
 
     @property
     def issuing_authority(self):
-        return self.__dict__.get("_DocumentDetails__issuing_authority", None)
+        return self.__issuing_authority
 
     def __validate_data(self, data):
         if self.VALIDATION_REGEX.search(data):


### PR DESCRIPTION
## Changed

* Defaulted non-required properties on `document_details` to `None` so we don't have to use hacky way of accessing a private property that might not have been initialised