### PR TITLE
SDK-1297: Refactor usage of date_parser

### DIFF
--- a/yoti_python_sdk/activity_details.py
+++ b/yoti_python_sdk/activity_details.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-import pytz
-
-from datetime import datetime
-
+from yoti_python_sdk import date_parser
 from yoti_python_sdk.profile import Profile, ApplicationProfile
 
 
@@ -25,8 +22,7 @@ class ActivityDetails:
         timestamp = receipt.get("timestamp")
 
         if timestamp is not None:
-            self.timestamp = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
-            self.timestamp = self.timestamp.replace(tzinfo=pytz.utc)
+            self.timestamp = date_parser.datetime_from_string(timestamp)
 
     @property
     def remember_me_id(self):

--- a/yoti_python_sdk/attribute_parser.py
+++ b/yoti_python_sdk/attribute_parser.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 import collections
 import json
 import logging
-import datetime
 
+from yoti_python_sdk import date_parser
 from yoti_python_sdk import multivalue
 from yoti_python_sdk.protobuf.protobuf import Protobuf
 
@@ -20,7 +20,7 @@ def value_based_on_content_type(value, content_type=None):
             "Content type: '{0}' should not have an empty value".format(content_type)
         )
     elif content_type == Protobuf.CT_DATE:
-        return parse_to_date(value.decode("utf-8"))
+        return date_parser.date_from_string(value.decode("utf-8"))
     elif content_type in Image.allowed_types():
         return Image(value, content_type)
     elif content_type == Protobuf.CT_JSON:
@@ -40,10 +40,6 @@ def value_based_on_content_type(value, content_type=None):
         )
 
     return value.decode("utf-8")
-
-
-def parse_to_date(date_str):
-    return datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
 
 
 def convert_to_dict(byte_value):

--- a/yoti_python_sdk/date_parser.py
+++ b/yoti_python_sdk/date_parser.py
@@ -1,12 +1,85 @@
 # -*- coding: utf-8 -*-
 
+import pytz
 import datetime
 
 
-def from_iso_format(string):
-    parts = [int(a) for a in string.split("-")]
+RFC_3999_DATE_FORMAT = "%Y-%m-%d"
+RFC_3999_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-    if len(parts) != 3:
-        raise ValueError
 
-    return datetime.date(parts[0], parts[1], parts[2])
+def parse_date(date_string, format_string):
+    """
+    Parse a date string into datetime.datetime object, using the specified format string
+
+    :param date_string: the raw date string
+    :param format_string: the format used to parse the date string
+    :return: datetime.datetime
+    """
+    return datetime.datetime.strptime(date_string, format_string).replace(
+        tzinfo=pytz.utc
+    )
+
+
+def date_from_string(date_string):
+    """
+    Parse a date string into datetime.date object, using RFC_3999 format
+
+    :param date_string: the raw date string
+    :return: datetime.date
+    """
+    return parse_date(date_string, RFC_3999_DATE_FORMAT).date()
+
+
+def datetime_from_string(date_string):
+    """
+    Parse a date string into datetime.datetime object, using RFC_3999 format
+
+    :param date_string: the raw date string
+    :return: datetime.datetime
+    """
+    return parse_date(date_string, RFC_3999_DATETIME_FORMAT)
+
+
+def parse_from_timestamp(timestamp, division=1):
+    """
+    Parses a timestamp into the number of seconds since epoch, dividing the timestamp by supplied
+    float
+
+    :param timestamp: the timestamp
+    :param division: the number to divide the timestamp by (default of 1, or no division)
+    :return: datetime.datetime
+    """
+    return datetime.datetime.utcfromtimestamp(timestamp / float(division)).replace(
+        tzinfo=pytz.utc
+    )
+
+
+def parse_timestamp_from_seconds(timestamp):
+    """
+    Parses a timestamp of number of seconds since epoch into datetime.datetime
+
+    :param timestamp: the timestamp
+    :return: datetime.datetime
+    """
+    return parse_from_timestamp(timestamp)
+
+
+def parse_timestamp_from_milliseconds(timestamp):
+    """
+    Parses a timestamp of number of milliseconds since epoch into datetime.datetime
+
+    :param timestamp: the timestamp
+    :return: datetime.datetime
+    """
+    return parse_from_timestamp(timestamp, division=1000)
+
+
+def parse_timestamp_from_microseconds(timestamp):
+    """
+    Parses a timestamp of number of microseconds since epoch into datetime.datetime
+
+    :param timestamp: the timestamp
+    :return: datetime.datetime
+    """
+    return parse_from_timestamp(timestamp, division=1000000)

--- a/yoti_python_sdk/document_details.py
+++ b/yoti_python_sdk/document_details.py
@@ -46,6 +46,6 @@ class DocumentDetails(object):
         if len(data) > 3:
             date = data[3]
             if date != "-":
-                self.__expiration_date = date_parser.from_iso_format(date)
+                self.__expiration_date = date_parser.date_from_string(date)
         if len(data) > 4:
             self.__issuing_authority = data[4]

--- a/yoti_python_sdk/tests/test_date_parser.py
+++ b/yoti_python_sdk/tests/test_date_parser.py
@@ -1,0 +1,181 @@
+import pytz
+import pytest
+
+from datetime import date, datetime
+
+from yoti_python_sdk import date_parser
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_type, expected_value",
+    [
+        ("1927-12-26", date, date(year=1927, month=12, day=26)),
+        ("1970-04-09", date, date(year=1970, month=4, day=9)),
+    ],
+)
+def test_date_from_string_valid(input_value, expected_type, expected_value):
+    result = date_parser.date_from_string(input_value)
+
+    assert isinstance(result, expected_type) is True
+    assert result == expected_value
+
+
+@pytest.mark.parametrize(
+    "input_value", ["1920, 1st of the Month!", "Why would we pass a string?"]
+)
+def test_date_from_string_throws_error_if_invalid_format(input_value):
+    with pytest.raises(ValueError) as ex:
+        date_parser.date_from_string(input_value)
+
+    assert "does not match format" in str(ex.value)
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_type, expected_value",
+    [
+        (
+            "1927-12-26T12:05:30Z",
+            datetime,
+            datetime(
+                year=1927,
+                month=12,
+                day=26,
+                hour=12,
+                minute=5,
+                second=30,
+                tzinfo=pytz.utc,
+            ),
+        ),
+        (
+            "1970-04-09T02:49:07Z",
+            datetime,
+            datetime(
+                year=1970, month=4, day=9, hour=2, minute=49, second=7, tzinfo=pytz.utc
+            ),
+        ),
+    ],
+)
+def test_datetime_from_string_valid(input_value, expected_type, expected_value):
+    result = date_parser.datetime_from_string(input_value)
+
+    assert isinstance(result, expected_type) is True
+    assert result == expected_value
+
+
+@pytest.mark.parametrize(
+    "input_value", ["1920, 1st of the Month!", "Why would we pass a string?"]
+)
+def test_datetime_from_string_throws_error_if_invalid_format(input_value):
+    with pytest.raises(ValueError) as ex:
+        date_parser.datetime_from_string(input_value)
+
+    assert "does not match format" in str(ex.value)
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_value",
+    [
+        (
+            1575030722,
+            datetime(
+                year=2019,
+                month=11,
+                day=29,
+                hour=12,
+                minute=32,
+                second=2,
+                tzinfo=pytz.utc,
+            ),
+        ),
+        (
+            -3829273028,
+            datetime(
+                year=1848,
+                month=8,
+                day=27,
+                hour=17,
+                minute=2,
+                second=52,
+                tzinfo=pytz.utc,
+            ),
+        ),
+    ],
+)
+def test_parse_timestamp_from_seconds(input_value, expected_value):
+    result = date_parser.parse_from_timestamp(input_value)
+
+    assert result == expected_value
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_value",
+    [
+        (
+            1575030722387,
+            datetime(
+                year=2019,
+                month=11,
+                day=29,
+                hour=12,
+                minute=32,
+                second=2,
+                microsecond=387000,
+                tzinfo=pytz.utc,
+            ),
+        ),
+        (
+            -3829273028324,
+            datetime(
+                year=1848,
+                month=8,
+                day=27,
+                hour=17,
+                minute=2,
+                second=51,
+                microsecond=676000,
+                tzinfo=pytz.utc,
+            ),
+        ),
+    ],
+)
+def test_parse_timestamp_from_milliseconds(input_value, expected_value):
+    result = date_parser.parse_timestamp_from_milliseconds(input_value)
+
+    assert result == expected_value
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_value",
+    [
+        (
+            1575030722387678,
+            datetime(
+                year=2019,
+                month=11,
+                day=29,
+                hour=12,
+                minute=32,
+                second=2,
+                microsecond=387678,
+                tzinfo=pytz.utc,
+            ),
+        ),
+        (
+            -3829273028324789,
+            datetime(
+                year=1848,
+                month=8,
+                day=27,
+                hour=17,
+                minute=2,
+                second=51,
+                microsecond=675211,
+                tzinfo=pytz.utc,
+            ),
+        ),
+    ],
+)
+def test_parse_timestamp_from_microseconds(input_value, expected_value):
+    result = date_parser.parse_timestamp_from_microseconds(input_value)
+
+    assert result == expected_value


### PR DESCRIPTION
## Added

* `date_parser`
  * I have added a load of helper functions which can be used to quickly parse dates/timestamps into the correct format, with all of the timezones set.
  * By centralising where all dates are formatted, we can easily make changes if needed which should be reflected throughout the whole SDK (previously each module controlled it's own date parsing)