### PR TITLE
SDK-1322: Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    target_branch: "development"
+
+    default_reviewers:
+      - "echarrod"
+      - "davidgrayston"
+      - "emmas-yoti"
+      - "MrBurtyyy"

--- a/examples/yoti_example_django/requirements.in
+++ b/examples/yoti_example_django/requirements.in
@@ -1,5 +1,5 @@
 cryptography>=2.3
-Django==2.2.4
+Django==2.2.8
 django-sslserver>=0.2.0
 python-dotenv>=0.7.1
 requests>=2.20.0

--- a/examples/yoti_example_django/requirements.txt
+++ b/examples/yoti_example_django/requirements.txt
@@ -11,7 +11,7 @@ cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 cryptography==2.5
 django-sslserver==0.20
-django==2.2.4
+django==2.2.8
 future==0.16.0            # via yoti
 idna==2.7                 # via requests
 protobuf==3.6.0           # via yoti


### PR DESCRIPTION
- Closed the dependabot PR as it was the wrong base branch
- Have added dependabot config so that it uses development as the base branch, and also adds us as reviewers