### PR TITLE
SDK-1337: Update pylint configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,3 @@
 [MASTER]
-ignore=yoti_python_sdk/tests/**,examples/**
+ignore=tests,protobuf
+disable=C0330

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setup(
             "pre-commit==1.17.0",
             "pytest>=3.6.0",
             "pytest-cov>=2.7.1",
+            "pylint==1.9.4",
+            "pylint-exit>=1.1.0",
             "python-coveralls==2.9.3",
             "mock==2.0.0",
             "virtualenv==15.2",


### PR DESCRIPTION
## Changed

* Updated pylint configuration to correctly ignore certain directories (such as auto-generated protobuf files), as well as to ignore specific pylint rules that may conflict with black formatter.