### PR TITLE
SDK-1443: Remove regex validation from document details

### DIFF
--- a/yoti_python_sdk/document_details.py
+++ b/yoti_python_sdk/document_details.py
@@ -27,8 +27,8 @@ class DocumentDetails(object):
         return self.__dict__.get("_DocumentDetails__issuing_authority", None)
 
     def __parse_data(self, data):
-        data = data.split()
-        if len(data) < 3:
+        data = data.split(" ")
+        if len(data) < 3 or "" in data:
             raise ValueError("Invalid value for DocumentDetails")
 
         self.__document_type = data[0]

--- a/yoti_python_sdk/document_details.py
+++ b/yoti_python_sdk/document_details.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
-import re
-
 from . import date_parser
 
 
 class DocumentDetails(object):
-    VALIDATION_REGEX = re.compile("^[A-Za-z_]* [A-Za-z]{3} [A-Za-z0-9]{1}.*$")
-
     def __init__(self, data):
-        self.__validate_data(data)
         self.__parse_data(data)
 
     @property
@@ -31,14 +26,10 @@ class DocumentDetails(object):
     def issuing_authority(self):
         return self.__dict__.get("_DocumentDetails__issuing_authority", None)
 
-    def __validate_data(self, data):
-        if self.VALIDATION_REGEX.search(data):
-            return
-        else:
-            raise ValueError("Invalid value for DocumentDetails")
-
     def __parse_data(self, data):
         data = data.split()
+        if len(data) < 3:
+            raise ValueError("Invalid value for DocumentDetails")
 
         self.__document_type = data[0]
         self.__issuing_country = data[1]

--- a/yoti_python_sdk/tests/test_document_details.py
+++ b/yoti_python_sdk/tests/test_document_details.py
@@ -124,10 +124,9 @@ def test_invalid_date():
         assert str(exc.value) == "Invalid value for DocumentDetails"
 
 
-def test_should_parse_with_double_space():
-    DATA = "AADHAAR  IND ****1234"
+def test_should_fail_with_double_space():
+    DATA = "  IND ****1234"
 
-    document = DocumentDetails(DATA)
-
-    assert document.document_type == "AADHAAR"
-    assert document.document_number == "****1234"
+    with pytest.raises(ValueError) as exc:
+        DocumentDetails(DATA)
+        assert str(exc.value) == "Invalid value for DocumentDetails"

--- a/yoti_python_sdk/tests/test_document_details.py
+++ b/yoti_python_sdk/tests/test_document_details.py
@@ -34,6 +34,40 @@ def test_parse_3_words():
     assert document.issuing_authority is None
 
 
+def test_parse_redacted_aadhaar():
+    DATA = "AADHAAR IND ****1234"
+
+    document = DocumentDetails(DATA)
+
+    assert document.document_type == "AADHAAR"
+    assert document.issuing_country == "IND"
+    assert document.document_number == "****1234"
+    assert document.expiration_date is None
+    assert document.issuing_authority is None
+
+
+@pytest.mark.parametrize(
+    "details, expected_number",
+    [
+        ("type country **** - authority", "****"),
+        (
+            "type country ~!@#$%^&*()-_=+[]{}|;':,./<>? - authority",
+            "~!@#$%^&*()-_=+[]{}|;':,./<>?",
+        ),
+        ('type country "" - authority', '""'),
+        ("type country \\ - authority", "\\"),
+        ('type country " - authority', '"'),
+        ("type country '' - authority", "''"),
+        ("type country ' - authority", "'"),
+    ],
+)
+def test_parse_special_characters(details, expected_number):
+    document = DocumentDetails(details)
+
+    assert document.document_type == "type"
+    assert document.document_number == expected_number
+
+
 def test_parse_4_words():
     DATA = "DRIVING_LICENCE GBR 1234abc 2016-05-01"
 
@@ -88,3 +122,12 @@ def test_invalid_date():
     with pytest.raises(ValueError) as exc:
         DocumentDetails(DATA)
         assert str(exc.value) == "Invalid value for DocumentDetails"
+
+
+def test_should_parse_with_double_space():
+    DATA = "AADHAAR  IND ****1234"
+
+    document = DocumentDetails(DATA)
+
+    assert document.document_type == "AADHAAR"
+    assert document.document_number == "****1234"

--- a/yoti_python_sdk/tests/test_document_details.py
+++ b/yoti_python_sdk/tests/test_document_details.py
@@ -125,7 +125,7 @@ def test_invalid_date():
 
 
 def test_should_fail_with_double_space():
-    DATA = "  IND ****1234"
+    DATA = "AADHAAR  IND ****1234"
 
     with pytest.raises(ValueError) as exc:
         DocumentDetails(DATA)


### PR DESCRIPTION
Support for parsing redacted aadhaar numbers

### Changed
 * Removed regex validation from `DocumentDetails`