### PR TITLE
SDK-1484: Update Cryptography: 2.7 -> 2.8

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 asn1==2.2.0
-cryptography>=2.7.0
+cryptography>=2.8.0
 cffi>=1.13.0
 future==0.15.2
 itsdangerous==0.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,10 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 asn1==2.2.0               # via -r requirements.in
-asn1crypto==0.24.0        # via cryptography
 certifi==2018.11.29       # via requests
 cffi==1.13.0              # via -r requirements.in, cryptography
 chardet==3.0.4            # via requests
-cryptography==2.7         # via -r requirements.in, pyopenssl
+cryptography==2.8         # via -r requirements.in, pyopenssl
 deprecated==1.2.6         # via -r requirements.in
 future==0.15.2            # via -r requirements.in
 idna==2.7                 # via requests


### PR DESCRIPTION
Aside from being a security update, Cryptography 2.8 also has:
- support for Python 3.8
- support for OpenSSL 1.1.1d.
- And no longer depends on asn1crypto.

Release notes: https://cryptography.io/en/latest/changelog/