### PR TITLE
Hotfix 2.11.1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 omit =
+    yoti_python_sdk/version.py
     yoti_python_sdk/tests/**
     yoti_python_sdk/protobuf/**/*
     examples/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.host.url = https://sonarcloud.io
 sonar.organization = getyoti
 sonar.projectKey = getyoti:python
 sonar.projectName = Python SDK
-sonar.projectVersion = 2.11.0
+sonar.projectVersion = 2.11.1
 sonar.exclusions = yoti_python_sdk/tests/**,examples/**,yoti_python_sdk/protobuf/**/*
 
 sonar.python.pylint.reportPath = coverage.out

--- a/yoti_python_sdk/doc_scan/session/retrieve/id_document_resource_response.py
+++ b/yoti_python_sdk/doc_scan/session/retrieve/id_document_resource_response.py
@@ -5,10 +5,10 @@ from yoti_python_sdk.doc_scan.session.retrieve.document_fields_response import (
     DocumentFieldsResponse,
 )
 from yoti_python_sdk.doc_scan.session.retrieve.page_response import PageResponse
-from yoti_python_sdk.doc_scan.session.retrieve.task_response import TaskResponse
+from yoti_python_sdk.doc_scan.session.retrieve.resource_response import ResourceResponse
 
 
-class IdDocumentResourceResponse(object):
+class IdDocumentResourceResponse(ResourceResponse):
     """
     Represents an Identity Document resource for a given session
     """
@@ -21,36 +21,16 @@ class IdDocumentResourceResponse(object):
         if data is None:
             data = dict()
 
-        self.__id = data.get("id", None)
+        ResourceResponse.__init__(self, data)
+
         self.__document_type = data.get("document_type", None)
         self.__issuing_country = data.get("issuing_country", None)
-        self.__tasks = [TaskResponse(task) for task in data.get("tasks", [])]
         self.__pages = [PageResponse(page) for page in data.get("pages", [])]
         self.__document_fields = (
             DocumentFieldsResponse(data["document_fields"])
             if "document_fields" in data.keys()
             else None
         )
-
-    @property
-    def id(self):
-        """
-        Returns the ID of the identity document
-
-        :return: the ID
-        :rtype: str or None
-        """
-        return self.__id
-
-    @property
-    def tasks(self):
-        """
-        Returns all associated tasks of the identity document
-
-        :return: the associated tasks
-        :rtype: list[TaskResponse]
-        """
-        return self.__tasks
 
     @property
     def document_type(self):

--- a/yoti_python_sdk/tests/doc_scan/session/retrieve/test_id_document_resource_response.py
+++ b/yoti_python_sdk/tests/doc_scan/session/retrieve/test_id_document_resource_response.py
@@ -6,13 +6,20 @@ from yoti_python_sdk.doc_scan.session.retrieve.document_fields_response import (
 from yoti_python_sdk.doc_scan.session.retrieve.id_document_resource_response import (
     IdDocumentResourceResponse,
 )
+from yoti_python_sdk.doc_scan.session.retrieve.task_response import (
+    TextExtractionTaskResponse,
+    TaskResponse,
+)
 
 
 class IdDocumentResourceResponseTest(unittest.TestCase):
     SOME_ID = "someId"
     SOME_DOCUMENT_TYPE = "someDocumentType"
     SOME_ISSUING_COUNTRY = "someIssuingCountry"
-    SOME_TASKS = [{"first": "task"}, {"second": "task"}]
+    SOME_TASKS = [
+        {"first": "task", "type": "ID_DOCUMENT_TEXT_DATA_EXTRACTION"},
+        {"second": "task"},
+    ]
     SOME_PAGES = [{"first": "page"}, {"second": "page"}]
     SOME_DOCUMENT_FIELDS = {"media": {}}
 
@@ -28,9 +35,9 @@ class IdDocumentResourceResponseTest(unittest.TestCase):
 
         result = IdDocumentResourceResponse(data)
 
-        assert result.id is self.SOME_ID
-        assert result.document_type is self.SOME_DOCUMENT_TYPE
-        assert result.issuing_country is self.SOME_ISSUING_COUNTRY
+        assert result.id == self.SOME_ID
+        assert result.document_type == self.SOME_DOCUMENT_TYPE
+        assert result.issuing_country == self.SOME_ISSUING_COUNTRY
         assert len(result.tasks) == 2
         assert len(result.pages) == 2
         assert isinstance(result.document_fields, DocumentFieldsResponse)
@@ -44,6 +51,22 @@ class IdDocumentResourceResponseTest(unittest.TestCase):
         assert len(result.tasks) == 0
         assert len(result.pages) == 0
         assert result.document_fields is None
+
+    def test_should_parse_tasks_with_type(self):
+        data = {
+            "id": self.SOME_ID,
+            "document_type": self.SOME_DOCUMENT_TYPE,
+            "issuing_country": self.SOME_ISSUING_COUNTRY,
+            "tasks": self.SOME_TASKS,
+            "pages": self.SOME_PAGES,
+            "document_fields": self.SOME_DOCUMENT_FIELDS,
+        }
+
+        result = IdDocumentResourceResponse(data)
+
+        assert len(result.tasks) == 2
+        assert isinstance(result.tasks[0], TextExtractionTaskResponse)
+        assert isinstance(result.tasks[1], TaskResponse)
 
 
 if __name__ == "__main__":

--- a/yoti_python_sdk/version.py
+++ b/yoti_python_sdk/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.11.0"
+__version__ = "2.11.1"


### PR DESCRIPTION
## Fixed

* `IdDocumentResourceResponse` now correctly inherits `ResourceResponse`
  * Although none of the properties were missing, tasks on all ID documents were being parsed as generic `TaskResponse` objects.
  * `TextExtractionTaskResponse` should now be available in the list of tasks