### PR TITLE
Hotfix 2.11.2

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.host.url = https://sonarcloud.io
 sonar.organization = getyoti
 sonar.projectKey = getyoti:python
 sonar.projectName = Python SDK
-sonar.projectVersion = 2.11.1
+sonar.projectVersion = 2.11.2
 sonar.exclusions = yoti_python_sdk/tests/**,examples/**,yoti_python_sdk/protobuf/**/*
 
 sonar.python.pylint.reportPath = coverage.out

--- a/yoti_python_sdk/doc_scan/client.py
+++ b/yoti_python_sdk/doc_scan/client.py
@@ -29,7 +29,7 @@ class DocScanClient(object):
         if api_url is not None:
             self.__api_url = api_url
         else:
-            self.__api_url = yoti_python_sdk.YOTI_DOC_SCAN_ENDPOINT
+            self.__api_url = yoti_python_sdk.YOTI_DOC_SCAN_API_URL
 
     def create_session(self, session_spec):
         """

--- a/yoti_python_sdk/tests/doc_scan/test_doc_scan_client.py
+++ b/yoti_python_sdk/tests/doc_scan/test_doc_scan_client.py
@@ -154,3 +154,10 @@ def test_should_throw_exception_for_delete_media(_, doc_scan_client):
     doc_scan_exception = ex.value  # type: DocScanException
     assert "Failed to delete media content" in str(doc_scan_exception)
     assert 404 == doc_scan_exception.status_code
+
+
+def test_should_use_correct_default_api_url(doc_scan_client):
+    assert (
+        doc_scan_client._DocScanClient__api_url
+        == "https://api.yoti.com:443/idverify/v1"
+    )  # noqa

--- a/yoti_python_sdk/version.py
+++ b/yoti_python_sdk/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.11.1"
+__version__ = "2.11.2"


### PR DESCRIPTION
## Fixed

* The incorrect default API URL was being used by the `DocScanClient`