### PR TITLE
Update packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,28 @@ jobs:
     - <<: *test
       python: "3.8"
       
+    - stage: Check Examples
+      name: AML 
+      python: "3.8"
+      script:
+        - cd ./examples/aml
+        - pip install -r requirements.txt
+    - name: Django
+      python: "3.8"
+      script:
+        - cd ./examples/yoti_example_django
+        - pip install -r requirements.txt
+    - name: Flask
+      python: "3.8"
+      script:
+        - cd ./examples/yoti_example_flask
+        - pip install -r requirements.txt
+    - name: Doc Scan
+      python: "3.8"
+      script:
+        - cd ./examples/doc_scan
+        - pip install -r requirements.txt
+
     - stage: Analyze
       name: Sonarcloud
       python: "3.8"

--- a/examples/aml/requirements.txt
+++ b/examples/aml/requirements.txt
@@ -1,2 +1,2 @@
-yoti>=2.9.0
+yoti>=2.12.1
 python-dotenv>=0.7.1

--- a/examples/doc_scan/requirements.in
+++ b/examples/doc_scan/requirements.in
@@ -1,5 +1,5 @@
 flask>=1.1.2
 python-dotenv>=0.13.0
-yoti>=2.11.2
+yoti>=2.12.1
 filetype>=1.0.7
 pyopenssl>=19.1.0

--- a/examples/doc_scan/requirements.txt
+++ b/examples/doc_scan/requirements.txt
@@ -28,7 +28,7 @@ six==1.14.0               # via cryptography, protobuf, pyopenssl
 urllib3==1.25.9           # via requests
 werkzeug==1.0.1           # via flask
 wrapt==1.12.1             # via deprecated
-yoti==2.11.2              # via -r requirements.in
+yoti==2.12.1              # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/examples/yoti_example_django/requirements.in
+++ b/examples/yoti_example_django/requirements.in
@@ -1,4 +1,3 @@
-cryptography>=2.9.2
 django>=3.0.7
 django-sslserver>=0.22.0
 python-dotenv>=0.7.1

--- a/examples/yoti_example_django/requirements.in
+++ b/examples/yoti_example_django/requirements.in
@@ -1,7 +1,7 @@
-cryptography>=2.3
-Django==2.2.8
-django-sslserver>=0.2.0
+cryptography>=2.9.2
+django>=3.0.7
+django-sslserver>=0.22.0
 python-dotenv>=0.7.1
 requests>=2.20.0
 urllib3>=1.24.2
-yoti>=2.9.0
+yoti>=2.12.1

--- a/examples/yoti_example_django/requirements.txt
+++ b/examples/yoti_example_django/requirements.txt
@@ -4,26 +4,29 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+asgiref==3.2.9            # via django
 asn1==2.2.0               # via yoti
-asn1crypto==0.24.0        # via cryptography
 certifi==2018.4.16        # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.5
-django-sslserver==0.20
-django==2.2.8
+cryptography==2.9.2       # via -r requirements.in, pyopenssl, yoti
+deprecated==1.2.6         # via yoti
+django-sslserver==0.22    # via -r requirements.in
+django==3.0.7             # via -r requirements.in, django-sslserver
 future==0.16.0            # via yoti
 idna==2.7                 # via requests
+iso8601==0.1.12           # via yoti
 protobuf==3.6.0           # via yoti
 pycparser==2.18           # via cffi
 pyopenssl==18.0.0         # via yoti
-python-dotenv==0.8.2
+python-dotenv==0.8.2      # via -r requirements.in
 pytz==2018.4              # via django
-requests==2.21.0
+requests==2.21.0          # via -r requirements.in, yoti
 six==1.11.0               # via cryptography, protobuf, pyopenssl
 sqlparse==0.3.0           # via django
-urllib3==1.24.2
-yoti==2.9.0
+urllib3==1.24.2           # via -r requirements.in, requests
+wrapt==1.12.1             # via deprecated
+yoti==2.12.1              # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via django-sslserver, protobuf
+# setuptools

--- a/examples/yoti_example_django/requirements.txt
+++ b/examples/yoti_example_django/requirements.txt
@@ -9,7 +9,7 @@ asn1==2.2.0               # via yoti
 certifi==2018.4.16        # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.9.2       # via -r requirements.in, pyopenssl, yoti
+cryptography==2.9.2       # via pyopenssl, yoti
 deprecated==1.2.6         # via yoti
 django-sslserver==0.22    # via -r requirements.in
 django==3.0.7             # via -r requirements.in, django-sslserver

--- a/examples/yoti_example_flask/requirements.in
+++ b/examples/yoti_example_flask/requirements.in
@@ -1,4 +1,3 @@
-cryptography>=2.9.2
 flask>=1.0.4
 jinja2>=2.8.1
 pyopenssl>=19.0.0

--- a/examples/yoti_example_flask/requirements.in
+++ b/examples/yoti_example_flask/requirements.in
@@ -1,8 +1,9 @@
-cryptography>=2.3
-Flask>=1.0.4
+cryptography>=2.9.2
+flask>=1.0.4
 jinja2>=2.8.1
 pyopenssl>=19.0.0
 python-dotenv>=0.7.1
 requests>=2.20.0
 urllib3>=1.24.2
-yoti>=2.9.0
+yoti>=2.12.1
+werkzeug>=1.0.1

--- a/examples/yoti_example_flask/requirements.in
+++ b/examples/yoti_example_flask/requirements.in
@@ -1,3 +1,4 @@
+cffi>=1.14.0
 flask>=1.0.4
 jinja2>=2.8.1
 pyopenssl>=19.0.0

--- a/examples/yoti_example_flask/requirements.txt
+++ b/examples/yoti_example_flask/requirements.txt
@@ -6,7 +6,7 @@
 #
 asn1==2.2.0               # via yoti
 certifi==2018.4.16        # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.14.0              # via -r requirements.in, cryptography
 chardet==3.0.4            # via requests
 click==6.7                # via flask
 cryptography==2.9.2       # via pyopenssl, yoti

--- a/examples/yoti_example_flask/requirements.txt
+++ b/examples/yoti_example_flask/requirements.txt
@@ -9,7 +9,7 @@ certifi==2018.4.16        # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 click==6.7                # via flask
-cryptography==2.9.2       # via -r requirements.in, pyopenssl, yoti
+cryptography==2.9.2       # via pyopenssl, yoti
 deprecated==1.2.6         # via yoti
 flask==1.1.1              # via -r requirements.in
 future==0.16.0            # via yoti

--- a/examples/yoti_example_flask/requirements.txt
+++ b/examples/yoti_example_flask/requirements.txt
@@ -5,27 +5,29 @@
 #    pip-compile --output-file=requirements.txt requirements.in
 #
 asn1==2.2.0               # via yoti
-asn1crypto==0.24.0        # via cryptography
 certifi==2018.4.16        # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 click==6.7                # via flask
-cryptography==2.5
-flask==1.1.1
+cryptography==2.9.2       # via -r requirements.in, pyopenssl, yoti
+deprecated==1.2.6         # via yoti
+flask==1.1.1              # via -r requirements.in
 future==0.16.0            # via yoti
 idna==2.7                 # via requests
+iso8601==0.1.12           # via yoti
 itsdangerous==0.24        # via flask
-jinja2==2.10.1
+jinja2==2.10.1            # via -r requirements.in, flask
 markupsafe==1.0           # via jinja2
 protobuf==3.6.0           # via yoti
 pycparser==2.18           # via cffi
-pyopenssl==19.0.0
-python-dotenv==0.8.2
-requests==2.21.0
+pyopenssl==19.0.0         # via -r requirements.in, yoti
+python-dotenv==0.8.2      # via -r requirements.in
+requests==2.21.0          # via -r requirements.in, yoti
 six==1.11.0               # via cryptography, protobuf, pyopenssl
-urllib3==1.24.2
-werkzeug==0.15.5          # via flask
-yoti==2.9.0
+urllib3==1.24.2           # via -r requirements.in, requests
+werkzeug==1.0.1           # via -r requirements.in, flask
+wrapt==1.12.1             # via deprecated
+yoti==2.12.1              # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via protobuf
+# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 asn1==2.3.1
-cryptography>=2.9.2
+cryptography==2.8.0
 cffi>=1.14.0
 future==0.18.2
 itsdangerous==0.24

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 asn1==2.3.1
-cryptography>=2.8.0
+cryptography>=2.9.2
 cffi>=1.14.0
 future==0.18.2
 itsdangerous==0.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ asn1==2.3.1               # via -r requirements.in
 certifi==2018.11.29       # via requests
 cffi==1.14.0              # via -r requirements.in, cryptography
 chardet==3.0.4            # via requests
-cryptography==2.8         # via -r requirements.in, pyopenssl
+cryptography==2.9.2       # via -r requirements.in, pyopenssl
 deprecated==1.2.10        # via -r requirements.in
 enum34==1.1.10            # via asn1
 future==0.18.2            # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ asn1==2.3.1               # via -r requirements.in
 certifi==2018.11.29       # via requests
 cffi==1.14.0              # via -r requirements.in, cryptography
 chardet==3.0.4            # via requests
-cryptography==2.9.2       # via -r requirements.in, pyopenssl
+cryptography==2.8         # via -r requirements.in, pyopenssl
 deprecated==1.2.10        # via -r requirements.in
 enum34==1.1.10            # via asn1
 future==0.18.2            # via -r requirements.in

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,11 @@ setup(
     ],
     extras_require={
         "examples": [
-            "Django>1.11.16",
-            "Flask>=0.10",
+            "Django>=3.0.7",
+            "Flask>=1.0.4",
             "python-dotenv>=0.7.1",
-            "django-sslserver>=0.2",
-            "Werkzeug==0.15.3",
+            "django-sslserver>=0.22.0",
+            "Werkzeug==1.0.1",
         ],
         "dev": [
             "pre-commit==1.17.0",


### PR DESCRIPTION
- Was having trouble getting all the packages to be in sync, so thought it would be best to add checks to Travis
- I think we might want to revisit whether we need a `examples` section in the `setup.py`, as I think it makes more sense to install the separate requirements for each demo as we need, but will revisit that another time

This again brings up package issues with everyone else dropping support for Python 3.4. The sooner we can drop that, the better!