### PR TITLE
Revert to asn1 2.2.0 to avoid using enum34

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-asn1==2.3.1
+asn1==2.2.0 # asn1 2.3.0 introduces enum34 as a dependency, which causes problems on some envs
 cryptography==2.8.0
 cffi>=1.14.0
 future==0.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,12 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-asn1==2.3.1               # via -r requirements.in
+asn1==2.2.0               # via -r requirements.in
 certifi==2018.11.29       # via requests
 cffi==1.14.0              # via -r requirements.in, cryptography
 chardet==3.0.4            # via requests
 cryptography==2.8         # via -r requirements.in, pyopenssl
 deprecated==1.2.10        # via -r requirements.in
-enum34==1.1.10            # via asn1
 future==0.18.2            # via -r requirements.in
 idna==2.7                 # via requests
 iso8601==0.1.12           # via -r requirements.in

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "protobuf>=3.1.0",
         "requests>=2.11.1",
         "future>=0.11.0",
-        "asn1==2.3.1",
+        "asn1==2.2.0",
         "pyopenssl>=18.0.0",
         "iso8601==0.1.12",
     ],


### PR DESCRIPTION
enum34 installation seems to clash with `enum` in path for _some_ environments (we found this for our integration tests using python-alpine docker images).
See:
- https://stackoverflow.com/questions/43124775/why-python-3-6-1-throws-attributeerror-module-enum-has-no-attribute-intflag
- https://github.com/iterative/dvc/issues/1995

Tried the other solutions mentioned there, removing asn1 is the cleanest, as it never installs enum34 in the first place