### PR TITLE
SDK-1669: Base64 URL token

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.host.url = https://sonarcloud.io
 sonar.organization = getyoti
 sonar.projectKey = getyoti:python
 sonar.projectName = Python SDK
-sonar.projectVersion = 2.12.2
+sonar.projectVersion = 2.12.3
 sonar.exclusions = yoti_python_sdk/tests/**,examples/**,yoti_python_sdk/protobuf/**/*
 
 sonar.python.pylint.reportPath = coverage.out

--- a/yoti_python_sdk/attribute_issuance_details.py
+++ b/yoti_python_sdk/attribute_issuance_details.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from yoti_python_sdk import date_parser
-import base64
+from yoti_python_sdk.utils import urlsafe_b64encode_unpadded
 
 
 class Definition(object):
@@ -15,7 +15,7 @@ class Definition(object):
 
 class AttributeIssuanceDetails(object):
     def __init__(self, data_entry):
-        self.__token = base64.b64encode(data_entry.issuance_token)
+        self.__token = urlsafe_b64encode_unpadded(data_entry.issuance_token)
         self.__expiry_date = date_parser.datetime_with_microsecond(
             data_entry.issuing_attributes.expiry_date
         )

--- a/yoti_python_sdk/tests/share/test_extra_data.py
+++ b/yoti_python_sdk/tests/share/test_extra_data.py
@@ -2,10 +2,10 @@
 
 from datetime import datetime
 import os.path
-import base64
 
 from yoti_python_sdk.share.extra_data import ExtraData
 from yoti_python_sdk.tests import file_helper
+from yoti_python_sdk.utils import urlsafe_b64encode_unpadded
 
 from yoti_python_sdk.protobuf.share_public_api import IssuingAttributes_pb2
 from yoti_python_sdk.protobuf.share_public_api import ThirdPartyAttribute_pb2
@@ -67,8 +67,9 @@ def test_should_return_first_matching_third_party_attribute():
         create_extra_data([thirdparty_attribute1, thirdparty_attribute2])
     )
 
-    assert parsed_extra_data.attribute_issuance_details.token == base64.b64encode(
-        "tokenValue1".encode("utf-8")
+    assert (
+        parsed_extra_data.attribute_issuance_details.token
+        == urlsafe_b64encode_unpadded(b"tokenValue1")
     )
     assert (
         parsed_extra_data.attribute_issuance_details.attributes[0].name
@@ -82,7 +83,7 @@ def test_should_parse_multiple_issuing_attributes():
 
     result = extra_data.attribute_issuance_details
     assert result is not None
-    assert result.token == base64.b64encode("someIssuanceToken".encode("utf-8"))
+    assert result.token == urlsafe_b64encode_unpadded(b"someIssuanceToken")
     assert result.expiry_date == datetime(2019, 10, 15, 22, 4, 5, 123000)
     assert result.attributes[0].name == "com.thirdparty.id"
     assert result.attributes[1].name == "com.thirdparty.other_id"
@@ -106,7 +107,8 @@ def test_should_handle_no_issuing_attributes():
     extra_data = ExtraData(create_extra_data([thirdparty_attribute]))
 
     result = extra_data.attribute_issuance_details
-    assert result.token == base64.b64encode(tokenValue.encode("utf-8"))
+    assert result.token == urlsafe_b64encode_unpadded(tokenValue.encode("utf-8"))
+
     assert len(result.attributes) == 0
 
 
@@ -119,6 +121,6 @@ def test_should_handle_no_issuing_attribute_definitions():
     extra_data = ExtraData(create_extra_data([thirdparty_attribute]))
 
     result = extra_data.attribute_issuance_details
-    assert result.token == base64.b64encode(tokenValue.encode("utf-8"))
+    assert result.token == urlsafe_b64encode_unpadded(tokenValue.encode("utf-8"))
     assert result.expiry_date == expiry_date
     assert len(result.attributes) == 0

--- a/yoti_python_sdk/tests/test_attribute_issuance_details.py
+++ b/yoti_python_sdk/tests/test_attribute_issuance_details.py
@@ -5,8 +5,8 @@ from yoti_python_sdk.tests import file_helper
 from yoti_python_sdk.attribute_issuance_details import AttributeIssuanceDetails
 from yoti_python_sdk.protobuf.share_public_api import ThirdPartyAttribute_pb2
 from yoti_python_sdk.protobuf.share_public_api import IssuingAttributes_pb2
+from yoti_python_sdk.utils import urlsafe_b64encode_unpadded, urlsafe_b64decode_unpadded
 from datetime import datetime
-import base64
 import pytest
 
 FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
@@ -36,9 +36,8 @@ def test_should_parse_third_party_attribute_correctly():
     issuance_details = AttributeIssuanceDetails(proto)
 
     assert issuance_details.attributes[0].name == "com.thirdparty.id"
-    assert issuance_details.token == base64.b64encode(
-        "someIssuanceToken".encode("utf-8")
-    )
+    assert issuance_details.token == urlsafe_b64encode_unpadded(b"someIssuanceToken")
+    assert urlsafe_b64decode_unpadded(issuance_details.token) == b"someIssuanceToken"
     assert issuance_details.expiry_date == datetime(2019, 10, 15, 22, 4, 5, 123000)
 
 

--- a/yoti_python_sdk/tests/test_util.py
+++ b/yoti_python_sdk/tests/test_util.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import pytest
+import base64
+
+from yoti_python_sdk.utils import urlsafe_b64encode_unpadded, urlsafe_b64decode_unpadded
+
+
+@pytest.mark.parametrize(
+    "b64url, b64",
+    [
+        ("HT-sGfUaHj-rDA", "HT+sGfUaHj+rDA=="),
+        ("X_uuRoHwt9_B6g", "X/uuRoHwt9/B6g=="),
+        ("eZU8xcW_eJ4", "eZU8xcW/eJ4="),
+        ("-OyhuDs6dAg", "+OyhuDs6dAg="),
+        ("c3RyaW5n", "c3RyaW5n"),
+    ],
+)
+def test_urlsafe_b64decode_unpadded(b64url, b64):
+    b64url_decoded = urlsafe_b64decode_unpadded(b64url)
+
+    assert base64.b64encode(b64url_decoded).decode("UTF-8") == b64
+
+
+@pytest.mark.parametrize(
+    "b64url_padded, b64",
+    [("HT-sGfUaHj-rDA==", "HT+sGfUaHj+rDA=="), ("eZU8xcW_eJ4=", "eZU8xcW/eJ4=")],
+)
+def test_urlsafe_b64decode_unpadded_with_padded_values(b64url_padded, b64):
+    b64url_decoded = urlsafe_b64decode_unpadded(b64url_padded)
+
+    assert base64.b64encode(b64url_decoded).decode("UTF-8") == b64
+
+
+@pytest.mark.parametrize(
+    "b64url, b64",
+    [
+        ("HT-sGfUaHj-rDA", "HT+sGfUaHj+rDA=="),
+        ("X_uuRoHwt9_B6g", "X/uuRoHwt9/B6g=="),
+        ("eZU8xcW_eJ4", "eZU8xcW/eJ4="),
+        ("-OyhuDs6dAg", "+OyhuDs6dAg="),
+        ("c3RyaW5n", "c3RyaW5n"),
+    ],
+)
+def test_urlsafe_b64encode_unpadded(b64url, b64):
+    assert urlsafe_b64encode_unpadded(base64.b64decode(b64)) == b64url

--- a/yoti_python_sdk/utils.py
+++ b/yoti_python_sdk/utils.py
@@ -1,3 +1,4 @@
+import base64
 import time
 import uuid
 from abc import ABCMeta
@@ -40,3 +41,27 @@ def create_timestamp():
     :return: the timestamp as a int
     """
     return int(time.time() * 1000)
+
+
+def urlsafe_b64encode_unpadded(b):
+    """
+    Base64 URL encode without padding
+    \
+    :param b: the bytes to encode
+    :type b: bytes
+    :return: the encoded string
+    :rtype: string
+    """
+    return base64.urlsafe_b64encode(b).decode("utf-8").rstrip("=")
+
+
+def urlsafe_b64decode_unpadded(s):
+    """
+    Base64 URL decode without padding
+    \
+    :param s: the string to decode
+    :type s: string
+    :return: the decoded bytes
+    :rtype: bytes
+    """
+    return base64.urlsafe_b64decode((s + "==").encode("utf-8"))

--- a/yoti_python_sdk/version.py
+++ b/yoti_python_sdk/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.12.2"
+__version__ = "2.12.3"


### PR DESCRIPTION
> Version `2.12.3`

### Fixed
- Attribute Issuance token is now base64 URL encoded
