### PR TITLE
NA: use pytest instead of py.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - pip install -r requirements.txt
         - pip install -e .[dev]
       script:
-        - py.test -v
+        - pytest -v
     - <<: *test
       python: "3.4"
     - <<: *test

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Running the tests is done by the following process, ensuring you are using Pytho
 
 1. Install dependencies: `pip install -r requirements.txt`
 1. Install the SDK and development dependencies: `pip install .[dev]`
-1. Execute in the main project dir: `py.test`
+1. Execute in the main project dir: `pytest`
 
 ## API Coverage
 


### PR DESCRIPTION
- Use pytest instead of py.test (see https://stackoverflow.com/questions/39495429/py-test-vs-pytest-command)
> The py.test invocation is the old and busted joint. pytest is the new hotness (since 3.0). py.test and pytest invocations will coexist for a long time I guess, but at some point py.test might be deprecated. So I would recommend to #dropthedot.
