### PR TITLE
SDK-1718: Remove null values from JSON payload

### DIFF
--- a/yoti_python_sdk/doc_scan/session/create/check/document_authenticity.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/document_authenticity.py
@@ -14,6 +14,9 @@ class RequestedDocumentAuthenticityCheckConfig(YotiSerializable):
     def to_json(self):
         return {}
 
+    def include_null_values(self):
+        return False
+
 
 class RequestedDocumentAuthenticityCheck(RequestedCheck):
     """

--- a/yoti_python_sdk/doc_scan/session/create/check/document_authenticity.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/document_authenticity.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from yoti_python_sdk.doc_scan.constants import ID_DOCUMENT_AUTHENTICITY
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 from .requested_check import RequestedCheck
 
 
@@ -12,10 +12,7 @@ class RequestedDocumentAuthenticityCheckConfig(YotiSerializable):
     """
 
     def to_json(self):
-        return {}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values({})
 
 
 class RequestedDocumentAuthenticityCheck(RequestedCheck):

--- a/yoti_python_sdk/doc_scan/session/create/check/face_match.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/face_match.py
@@ -32,6 +32,9 @@ class RequestedFaceMatchCheckConfig(YotiSerializable):
     def to_json(self):
         return {"manual_check": self.manual_check}
 
+    def include_null_values(self):
+        return False
+
 
 class RequestedFaceMatchCheck(RequestedCheck):
     """

--- a/yoti_python_sdk/doc_scan/session/create/check/face_match.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/face_match.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from yoti_python_sdk.doc_scan import constants
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 from .requested_check import RequestedCheck
 
 
@@ -30,10 +30,7 @@ class RequestedFaceMatchCheckConfig(YotiSerializable):
         return self.__manual_check
 
     def to_json(self):
-        return {"manual_check": self.manual_check}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values({"manual_check": self.manual_check})
 
 
 class RequestedFaceMatchCheck(RequestedCheck):

--- a/yoti_python_sdk/doc_scan/session/create/check/liveness.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/liveness.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from yoti_python_sdk.doc_scan import constants
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 from .requested_check import RequestedCheck
 
 
@@ -40,10 +40,9 @@ class RequestedLivenessCheckConfig(YotiSerializable):
         return self.__max_retries
 
     def to_json(self):
-        return {"liveness_type": self.liveness_type, "max_retries": self.max_retries}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(
+            {"liveness_type": self.liveness_type, "max_retries": self.max_retries}
+        )
 
 
 class RequestedLivenessCheck(RequestedCheck):

--- a/yoti_python_sdk/doc_scan/session/create/check/liveness.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/liveness.py
@@ -42,6 +42,9 @@ class RequestedLivenessCheckConfig(YotiSerializable):
     def to_json(self):
         return {"liveness_type": self.liveness_type, "max_retries": self.max_retries}
 
+    def include_null_values(self):
+        return False
+
 
 class RequestedLivenessCheck(RequestedCheck):
     """

--- a/yoti_python_sdk/doc_scan/session/create/check/requested_check.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/requested_check.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta
 from abc import abstractmethod
 
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 
 
 class RequestedCheck(YotiSerializable):
@@ -33,7 +33,4 @@ class RequestedCheck(YotiSerializable):
         raise NotImplementedError
 
     def to_json(self):
-        return {"type": self.type, "config": self.config}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values({"type": self.type, "config": self.config})

--- a/yoti_python_sdk/doc_scan/session/create/check/requested_check.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/requested_check.py
@@ -34,3 +34,6 @@ class RequestedCheck(YotiSerializable):
 
     def to_json(self):
         return {"type": self.type, "config": self.config}
+
+    def include_null_values(self):
+        return False

--- a/yoti_python_sdk/doc_scan/session/create/filter/document_filter.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/document_filter.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta
 
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 
 
 class DocumentFilter(YotiSerializable):
@@ -14,7 +14,4 @@ class DocumentFilter(YotiSerializable):
         return self.__filter_type
 
     def to_json(self):
-        return {"type": self.type}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values({"type": self.type})

--- a/yoti_python_sdk/doc_scan/session/create/filter/document_filter.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/document_filter.py
@@ -15,3 +15,6 @@ class DocumentFilter(YotiSerializable):
 
     def to_json(self):
         return {"type": self.type}
+
+    def include_null_values(self):
+        return False

--- a/yoti_python_sdk/doc_scan/session/create/filter/document_restrictions_filter.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/document_restrictions_filter.py
@@ -26,6 +26,9 @@ class DocumentRestriction(YotiSerializable):
             "document_types": self.document_types,
         }
 
+    def include_null_values(self):
+        return False
+
 
 class DocumentRestrictionBuilder(object):
     def __init__(self):
@@ -86,6 +89,9 @@ class DocumentRestrictionsFilter(DocumentFilter):
         parent["inclusion"] = self.inclusion
         parent["documents"] = self.documents
         return parent
+
+    def include_null_values(self):
+        return False
 
 
 class DocumentRestrictionsFilterBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/filter/document_restrictions_filter.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/document_restrictions_filter.py
@@ -3,7 +3,7 @@ from yoti_python_sdk.doc_scan.constants import (
     INCLUSION_BLACKLIST,
     INCLUSION_WHITELIST,
 )
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 from .document_filter import DocumentFilter
 
 
@@ -21,13 +21,12 @@ class DocumentRestriction(YotiSerializable):
         return self.__document_types
 
     def to_json(self):
-        return {
-            "country_codes": self.country_codes,
-            "document_types": self.document_types,
-        }
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(
+            {
+                "country_codes": self.country_codes,
+                "document_types": self.document_types,
+            }
+        )
 
 
 class DocumentRestrictionBuilder(object):
@@ -88,10 +87,7 @@ class DocumentRestrictionsFilter(DocumentFilter):
         parent = DocumentFilter.to_json(self)
         parent["inclusion"] = self.inclusion
         parent["documents"] = self.documents
-        return parent
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(parent)
 
 
 class DocumentRestrictionsFilterBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/filter/orthogonal_restrictions_filter.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/orthogonal_restrictions_filter.py
@@ -1,7 +1,7 @@
 from yoti_python_sdk.doc_scan.constants import INCLUSION_BLACKLIST
 from yoti_python_sdk.doc_scan.constants import INCLUSION_WHITELIST
 from yoti_python_sdk.doc_scan.constants import ORTHOGONAL_RESTRICTIONS
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 from .document_filter import DocumentFilter
 
 
@@ -31,10 +31,9 @@ class CountryRestriction(YotiSerializable):
         return self.__country_codes
 
     def to_json(self):
-        return {"inclusion": self.inclusion, "country_codes": self.country_codes}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(
+            {"inclusion": self.inclusion, "country_codes": self.country_codes}
+        )
 
 
 class TypeRestriction(YotiSerializable):
@@ -63,10 +62,9 @@ class TypeRestriction(YotiSerializable):
         return self.__document_types
 
     def to_json(self):
-        return {"inclusion": self.inclusion, "document_types": self.document_types}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(
+            {"inclusion": self.inclusion, "document_types": self.document_types}
+        )
 
 
 class OrthogonalRestrictionsFilter(DocumentFilter):
@@ -100,10 +98,7 @@ class OrthogonalRestrictionsFilter(DocumentFilter):
         parent = DocumentFilter.to_json(self)
         parent["country_restriction"] = self.country_restriction
         parent["type_restriction"] = self.type_restriction
-        return parent
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(parent)
 
 
 class OrthogonalRestrictionsFilterBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/filter/orthogonal_restrictions_filter.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/orthogonal_restrictions_filter.py
@@ -33,6 +33,9 @@ class CountryRestriction(YotiSerializable):
     def to_json(self):
         return {"inclusion": self.inclusion, "country_codes": self.country_codes}
 
+    def include_null_values(self):
+        return False
+
 
 class TypeRestriction(YotiSerializable):
     def __init__(self, inclusion, document_types):
@@ -61,6 +64,9 @@ class TypeRestriction(YotiSerializable):
 
     def to_json(self):
         return {"inclusion": self.inclusion, "document_types": self.document_types}
+
+    def include_null_values(self):
+        return False
 
 
 class OrthogonalRestrictionsFilter(DocumentFilter):
@@ -95,6 +101,9 @@ class OrthogonalRestrictionsFilter(DocumentFilter):
         parent["country_restriction"] = self.country_restriction
         parent["type_restriction"] = self.type_restriction
         return parent
+
+    def include_null_values(self):
+        return False
 
 
 class OrthogonalRestrictionsFilterBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/filter/required_id_document.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/required_id_document.py
@@ -22,6 +22,9 @@ class RequiredIdDocument(RequiredDocument):
     def to_json(self):
         return {"type": self.type, "filter": self.__doc_filter}
 
+    def include_null_values(self):
+        return False
+
 
 class RequiredIdDocumentBuilder(object):
     """

--- a/yoti_python_sdk/doc_scan/session/create/filter/required_id_document.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/required_id_document.py
@@ -1,4 +1,5 @@
 from yoti_python_sdk.doc_scan.constants import ID_DOCUMENT
+from yoti_python_sdk.utils import remove_null_values
 from .document_filter import DocumentFilter  # noqa: F401
 from .required_document import RequiredDocument
 
@@ -20,10 +21,7 @@ class RequiredIdDocument(RequiredDocument):
         return self.__doc_filter
 
     def to_json(self):
-        return {"type": self.type, "filter": self.__doc_filter}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values({"type": self.type, "filter": self.__doc_filter})
 
 
 class RequiredIdDocumentBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/notification_config.py
+++ b/yoti_python_sdk/doc_scan/session/create/notification_config.py
@@ -5,7 +5,7 @@ from yoti_python_sdk.doc_scan.constants import CHECK_COMPLETION
 from yoti_python_sdk.doc_scan.constants import RESOURCE_UPDATE
 from yoti_python_sdk.doc_scan.constants import SESSION_COMPLETION
 from yoti_python_sdk.doc_scan.constants import TASK_COMPLETION
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 
 
 class NotificationConfig(YotiSerializable):
@@ -63,14 +63,13 @@ class NotificationConfig(YotiSerializable):
         return self.__topics
 
     def to_json(self):
-        return {
-            "auth_token": self.auth_token,
-            "endpoint": self.endpoint,
-            "topics": self.topics,
-        }
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(
+            {
+                "auth_token": self.auth_token,
+                "endpoint": self.endpoint,
+                "topics": self.topics,
+            }
+        )
 
 
 class NotificationConfigBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/notification_config.py
+++ b/yoti_python_sdk/doc_scan/session/create/notification_config.py
@@ -69,6 +69,9 @@ class NotificationConfig(YotiSerializable):
             "topics": self.topics,
         }
 
+    def include_null_values(self):
+        return False
+
 
 class NotificationConfigBuilder(object):
     """

--- a/yoti_python_sdk/doc_scan/session/create/sdk_config.py
+++ b/yoti_python_sdk/doc_scan/session/create/sdk_config.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from yoti_python_sdk.doc_scan.constants import CAMERA
 from yoti_python_sdk.doc_scan.constants import CAMERA_AND_UPLOAD
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 
 
 class SdkConfig(YotiSerializable):
@@ -122,19 +122,18 @@ class SdkConfig(YotiSerializable):
         return self.__error_url
 
     def to_json(self):
-        return {
-            "allowed_capture_methods": self.allowed_capture_methods,
-            "primary_colour": self.primary_colour,
-            "secondary_colour": self.secondary_colour,
-            "font_colour": self.font_colour,
-            "locale": self.locale,
-            "preset_issuing_country": self.preset_issuing_country,
-            "success_url": self.success_url,
-            "error_url": self.error_url,
-        }
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(
+            {
+                "allowed_capture_methods": self.allowed_capture_methods,
+                "primary_colour": self.primary_colour,
+                "secondary_colour": self.secondary_colour,
+                "font_colour": self.font_colour,
+                "locale": self.locale,
+                "preset_issuing_country": self.preset_issuing_country,
+                "success_url": self.success_url,
+                "error_url": self.error_url,
+            }
+        )
 
 
 class SdkConfigBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/sdk_config.py
+++ b/yoti_python_sdk/doc_scan/session/create/sdk_config.py
@@ -133,6 +133,9 @@ class SdkConfig(YotiSerializable):
             "error_url": self.error_url,
         }
 
+    def include_null_values(self):
+        return False
+
 
 class SdkConfigBuilder(object):
     """

--- a/yoti_python_sdk/doc_scan/session/create/session_spec.py
+++ b/yoti_python_sdk/doc_scan/session/create/session_spec.py
@@ -150,6 +150,9 @@ class SessionSpec(YotiSerializable):
             "required_documents": self.required_documents,
         }
 
+    def include_null_values(self):
+        return False
+
 
 class SessionSpecBuilder(object):
     """

--- a/yoti_python_sdk/doc_scan/session/create/session_spec.py
+++ b/yoti_python_sdk/doc_scan/session/create/session_spec.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from .filter.required_document import RequiredDocument  # noqa: F401
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 
 
 class SessionSpec(YotiSerializable):
@@ -139,19 +139,18 @@ class SessionSpec(YotiSerializable):
         return self.__required_documents
 
     def to_json(self):
-        return {
-            "client_session_token_ttl": self.client_session_token_ttl,
-            "resources_ttl": self.resources_ttl,
-            "user_tracking_id": self.user_tracking_id,
-            "notifications": self.notifications,
-            "requested_checks": self.requested_checks,
-            "requested_tasks": self.requested_tasks,
-            "sdk_config": self.sdk_config,
-            "required_documents": self.required_documents,
-        }
-
-    def include_null_values(self):
-        return False
+        return remove_null_values(
+            {
+                "client_session_token_ttl": self.client_session_token_ttl,
+                "resources_ttl": self.resources_ttl,
+                "user_tracking_id": self.user_tracking_id,
+                "notifications": self.notifications,
+                "requested_checks": self.requested_checks,
+                "requested_tasks": self.requested_tasks,
+                "sdk_config": self.sdk_config,
+                "required_documents": self.required_documents,
+            }
+        )
 
 
 class SessionSpecBuilder(object):

--- a/yoti_python_sdk/doc_scan/session/create/task/requested_task.py
+++ b/yoti_python_sdk/doc_scan/session/create/task/requested_task.py
@@ -34,3 +34,6 @@ class RequestedTask(YotiSerializable):
 
     def to_json(self):
         return {"type": self.type, "config": self.config}
+
+    def include_null_values(self):
+        return False

--- a/yoti_python_sdk/doc_scan/session/create/task/requested_task.py
+++ b/yoti_python_sdk/doc_scan/session/create/task/requested_task.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta
 from abc import abstractmethod
 
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 
 
 class RequestedTask(YotiSerializable):
@@ -33,7 +33,4 @@ class RequestedTask(YotiSerializable):
         raise NotImplementedError
 
     def to_json(self):
-        return {"type": self.type, "config": self.config}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values({"type": self.type, "config": self.config})

--- a/yoti_python_sdk/doc_scan/session/create/task/text_extraction.py
+++ b/yoti_python_sdk/doc_scan/session/create/task/text_extraction.py
@@ -26,6 +26,9 @@ class RequestedTextExtractionTaskConfig(YotiSerializable):
     def to_json(self):
         return {"manual_check": self.manual_check}
 
+    def include_null_values(self):
+        return False
+
 
 class RequestedTextExtractionTask(RequestedTask):
     """

--- a/yoti_python_sdk/doc_scan/session/create/task/text_extraction.py
+++ b/yoti_python_sdk/doc_scan/session/create/task/text_extraction.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from yoti_python_sdk.doc_scan import constants
-from yoti_python_sdk.utils import YotiSerializable
+from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 from .requested_task import RequestedTask
 
 
@@ -24,10 +24,7 @@ class RequestedTextExtractionTaskConfig(YotiSerializable):
         return self.__manual_check
 
     def to_json(self):
-        return {"manual_check": self.manual_check}
-
-    def include_null_values(self):
-        return False
+        return remove_null_values({"manual_check": self.manual_check})
 
 
 class RequestedTextExtractionTask(RequestedTask):

--- a/yoti_python_sdk/tests/doc_scan/session/create/filter/test_document_restriction_builder.py
+++ b/yoti_python_sdk/tests/doc_scan/session/create/filter/test_document_restriction_builder.py
@@ -41,3 +41,15 @@ def test_to_json_should_not_throw_exception():
 
     s = json.dumps(result, cls=YotiEncoder)
     assert s is not None and s != ""
+
+
+def test_to_json_should_not_include_null_values():
+    result = (
+        DocumentRestrictionBuilder()
+        .with_document_types(["PASSPORT", "DRIVING_LICENCE"])
+        .build()
+    )
+
+    s = json.dumps(result, cls=YotiEncoder)
+    assert s is not None
+    assert "null" not in s

--- a/yoti_python_sdk/utils.py
+++ b/yoti_python_sdk/utils.py
@@ -16,10 +16,16 @@ class YotiSerializable(object):
     def to_json(self):
         raise NotImplementedError
 
+    def include_null_values(self):
+        return True
+
 
 class YotiEncoder(JSONEncoder):
     def default(self, o):
         if isinstance(o, YotiSerializable):
+            if not o.include_null_values():
+                return remove_null_values(o.to_json())
+
             return o.to_json()
         return JSONEncoder.default(self, o)
 
@@ -40,3 +46,15 @@ def create_timestamp():
     :return: the timestamp as a int
     """
     return int(time.time() * 1000)
+
+
+def remove_null_values(d):
+    """
+    Delete keys with the value ``None`` in a dictionary, recursively. (None serializes to null)
+    """
+    for key, value in list(d.items()):
+        if value is None:
+            del d[key]
+        elif isinstance(value, dict):
+            remove_null_values(value)
+    return d

--- a/yoti_python_sdk/utils.py
+++ b/yoti_python_sdk/utils.py
@@ -16,16 +16,10 @@ class YotiSerializable(object):
     def to_json(self):
         raise NotImplementedError
 
-    def include_null_values(self):
-        return True
-
 
 class YotiEncoder(JSONEncoder):
     def default(self, o):
         if isinstance(o, YotiSerializable):
-            if not o.include_null_values():
-                return remove_null_values(o.to_json())
-
             return o.to_json()
         return JSONEncoder.default(self, o)
 


### PR DESCRIPTION
Even if the objects don't have any values which currently serialize to null, I thought it would be best to specify that we don't want this behaviour, and then if we add any in the future, they will be excluded if null.

The alternative to this would be to ignore these values by default, and then we can override in any methods where we need to. 