### PR TITLE
SDK-1582: Include response error in exception message

### DIFF
--- a/yoti_python_sdk/doc_scan/exception/doc_scan_exception.py
+++ b/yoti_python_sdk/doc_scan/exception/doc_scan_exception.py
@@ -16,7 +16,7 @@ class DocScanException(Exception):
         """
         Exception.__init__(self)
 
-        response_message = self.__format_response_message(response)
+        response_message = self.__get_response_message(response)
 
         self.__message = message + (
             " - " + response_message if response_message else ""
@@ -63,18 +63,25 @@ class DocScanException(Exception):
         """
         return self.__response.content
 
-    def __format_response_message(self, response):
+    def __get_response_message(self, response):
         """
         Return the formatted response message
 
         :return: the formatted message
         :rtype: string or None
         """
-        if response.headers.get("Content-Type") != "application/json":
-            return None
+        if response.headers.get("Content-Type") == "application/json":
+            return self.__format_json_response_message(json.loads(response.text))
 
-        parsed = json.loads(response.text)
+        return None
 
+    def __format_json_response_message(self, parsed):
+        """
+        Return the formatted JSON response message
+
+        :return: the formatted message
+        :rtype: string or None
+        """
         if not parsed.get("code") or not parsed.get("message"):
             return None
 

--- a/yoti_python_sdk/tests/doc_scan/exception/test_doc_scan_exception.py
+++ b/yoti_python_sdk/tests/doc_scan/exception/test_doc_scan_exception.py
@@ -1,0 +1,90 @@
+import json
+
+from yoti_python_sdk.doc_scan.exception import DocScanException
+from yoti_python_sdk.tests.mocks import MockResponse
+
+
+def test_return_message():
+    response = MockResponse(status_code=400, text="some response")
+    exception = DocScanException("some error", response)
+
+    assert exception.message == "some error"
+
+
+def test_return_only_message_when_html_response():
+    response = MockResponse(
+        status_code=400,
+        text="<html>some html</html>",
+        headers={"Content-Type": "text/html"},
+    )
+    exception = DocScanException("some error", response)
+
+    assert exception.message == "some error"
+
+
+def test_return_only_message_when_json_response_has_no_message_property():
+    response = MockResponse(
+        status_code=400,
+        text=json.dumps({}),
+        headers={"Content-Type": "application/json"},
+    )
+    exception = DocScanException("some error", response)
+
+    assert exception.message == "some error"
+
+
+def test_return_formatted_response_code_and_message():
+    response = MockResponse(
+        status_code=400,
+        text=json.dumps({"code": "SOME_CODE", "message": "some message"}),
+        headers={"Content-Type": "application/json"},
+    )
+    exception = DocScanException("some error", response)
+
+    assert exception.message == "some error - SOME_CODE - some message"
+
+
+def test_return_formatted_response_code_message_and_errors():
+    response = MockResponse(
+        status_code=400,
+        text=json.dumps(
+            {
+                "code": "SOME_CODE",
+                "message": "some message",
+                "errors": [
+                    {"property": "some.property", "message": "some message"},
+                    {
+                        "property": "some.other.property",
+                        "message": "some other message",
+                    },
+                ],
+            }
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+    exception = DocScanException("some error", response)
+
+    assert (
+        exception.message
+        == 'some error - SOME_CODE - some message: some.property "some message", some.other.property "some other message"'
+    )
+
+
+def test_excludes_errors_without_property_or_message():
+    response = MockResponse(
+        status_code=400,
+        text=json.dumps(
+            {
+                "code": "SOME_CODE",
+                "message": "some message",
+                "errors": [
+                    {"message": "some message"},
+                    {"property": "some.other.property"},
+                ],
+            }
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+    exception = DocScanException("some error", response)
+
+    assert exception.message == "some error - SOME_CODE - some message"

--- a/yoti_python_sdk/tests/mocks.py
+++ b/yoti_python_sdk/tests/mocks.py
@@ -1,5 +1,6 @@
 import base64
 from uuid import UUID
+from requests.structures import CaseInsensitiveDict
 
 from yoti_python_sdk.http import RequestHandler
 from yoti_python_sdk.http import SignedRequest
@@ -11,7 +12,9 @@ class MockResponse(YotiResponse):
         if headers is None:
             headers = dict()
 
-        super(MockResponse, self).__init__(status_code, text, headers, content)
+        super(MockResponse, self).__init__(
+            status_code, text, CaseInsensitiveDict(headers), content
+        )
 
 
 class MockRequestHandler(RequestHandler):


### PR DESCRIPTION
### Added
- Formatted response error is now included in `DocScanException` message