### PR TITLE
SDK-1732: Allow manual check to be configured on authenticity checks

### DIFF
--- a/examples/doc_scan/app.py
+++ b/examples/doc_scan/app.py
@@ -50,7 +50,11 @@ def create_session():
         .with_client_session_token_ttl(600)
         .with_resources_ttl(90000)
         .with_user_tracking_id("some-user-tracking-id")
-        .with_requested_check(RequestedDocumentAuthenticityCheckBuilder().build())
+        .with_requested_check(
+            RequestedDocumentAuthenticityCheckBuilder()
+            .with_manual_check_never()
+            .build()
+        )
         .with_requested_check(
             RequestedLivenessCheckBuilder()
             .for_zoom_liveness()

--- a/yoti_python_sdk/doc_scan/session/create/check/document_authenticity.py
+++ b/yoti_python_sdk/doc_scan/session/create/check/document_authenticity.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from yoti_python_sdk.doc_scan.constants import ID_DOCUMENT_AUTHENTICITY
+from yoti_python_sdk.doc_scan import constants
 from yoti_python_sdk.utils import YotiSerializable, remove_null_values
 from .requested_check import RequestedCheck
 
@@ -11,8 +11,26 @@ class RequestedDocumentAuthenticityCheckConfig(YotiSerializable):
     The configuration applied when creating a Document Authenticity Check
     """
 
+    def __init__(self, manual_check=None):
+        """
+        :param manual_check: the manual check value
+        :type manual_check: str
+        """
+        self.__manual_check = manual_check
+
+    @property
+    def manual_check(self):
+        """
+        Returns a value for a manual check for a given
+        Authenticity Check
+
+        :return: the manual check value
+        :rtype: str
+        """
+        return self.__manual_check
+
     def to_json(self):
-        return remove_null_values({})
+        return remove_null_values({"manual_check": self.manual_check})
 
 
 class RequestedDocumentAuthenticityCheck(RequestedCheck):
@@ -29,19 +47,50 @@ class RequestedDocumentAuthenticityCheck(RequestedCheck):
 
     @property
     def type(self):
-        return ID_DOCUMENT_AUTHENTICITY
+        return constants.ID_DOCUMENT_AUTHENTICITY
 
     @property
     def config(self):
         return self.__config
 
 
-class RequestedDocumentAuthenticityCheckBuilder(object):
+class RequestedDocumentAuthenticityCheckBuilder:
     """
     Builder to assist creation of :class:`RequestedDocumentAuthenticityCheck`
     """
 
-    @staticmethod
-    def build():
-        config = RequestedDocumentAuthenticityCheckConfig()
+    def __init__(self):
+        self.__manual_check = None
+
+    def with_manual_check_always(self):
+        """
+        :return: the builder
+        :rtype: RequestedDocumentAuthenticityCheckBuilder
+        """
+        self.__manual_check = constants.ALWAYS
+        return self
+
+    def with_manual_check_fallback(self):
+        """
+        :return: the builder
+        :rtype: RequestedDocumentAuthenticityCheckBuilder
+        """
+        self.__manual_check = constants.FALLBACK
+        return self
+
+    def with_manual_check_never(self):
+        """
+        :return: the builder
+        :rtype: RequestedDocumentAuthenticityCheckBuilder
+        """
+        self.__manual_check = constants.NEVER
+        return self
+
+    def build(self=None):
+        if self is None:
+            manual_check = None
+        else:
+            manual_check = self.__manual_check
+
+        config = RequestedDocumentAuthenticityCheckConfig(manual_check)
         return RequestedDocumentAuthenticityCheck(config)

--- a/yoti_python_sdk/tests/doc_scan/session/create/check/test_requested_document_authenticity_check.py
+++ b/yoti_python_sdk/tests/doc_scan/session/create/check/test_requested_document_authenticity_check.py
@@ -29,6 +29,33 @@ class RequestedDocumentAuthenticityCheckTest(unittest.TestCase):
         s = json.dumps(result, cls=YotiEncoder)
         assert s is not None and s != ""
 
+    def test_should_build_with_manual_check_always(self):
+        result = (
+            RequestedDocumentAuthenticityCheckBuilder()
+            .with_manual_check_always()
+            .build()
+        )
+
+        assert result.config.manual_check == "ALWAYS"
+
+    def test_should_build_with_manual_check_fallback(self):
+        result = (
+            RequestedDocumentAuthenticityCheckBuilder()
+            .with_manual_check_fallback()
+            .build()
+        )
+
+        assert result.config.manual_check == "FALLBACK"
+
+    def test_should_build_with_manual_check_never(self):
+        result = (
+            RequestedDocumentAuthenticityCheckBuilder()
+            .with_manual_check_never()
+            .build()
+        )
+
+        assert result.config.manual_check == "NEVER"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Added
- Allow the configuration of the `manual_check` value for requested Document Authenticity checks

### Fixed
- `RequestedDocumentAuthenticityCheckBuilder.build()` is no longer static. Python 2 implementations must change this to `RequestedDocumentAuthenticityCheckBuilder().build()`