### PR TITLE
SDK-1809: Support media responses with no content

### DIFF
--- a/examples/doc_scan/app.py
+++ b/examples/doc_scan/app.py
@@ -73,9 +73,7 @@ def create_session():
         )
         .with_sdk_config(sdk_config)
         .with_required_document(build_required_id_document_restriction("PASSPORT"))
-        .with_required_document(
-            build_required_id_document_restriction("DRIVING_LICENCE")
-        )
+        .with_required_document(RequiredIdDocumentBuilder().build())
         .build()
     )
 
@@ -151,6 +149,9 @@ def media():
         retrieved_media = doc_scan_client.get_media_content(session_id, media_id)
     except DocScanException as e:
         return render_template("error.html", error=e.text)
+
+    if retrieved_media is None:
+        return Response("", status=204)
 
     return Response(
         retrieved_media.content, content_type=retrieved_media.mime_type, status=200

--- a/yoti_python_sdk/doc_scan/client.py
+++ b/yoti_python_sdk/doc_scan/client.py
@@ -138,6 +138,9 @@ class DocScanClient(object):
         )
         response = request.execute()
 
+        if response.status_code == 204:
+            return None
+
         if response.status_code != 200:
             raise DocScanException("Failed to retrieve media content", response)
 

--- a/yoti_python_sdk/tests/doc_scan/mocks.py
+++ b/yoti_python_sdk/tests/doc_scan/mocks.py
@@ -38,7 +38,11 @@ def mocked_request_media_content():
     )
 
 
-def mocked_request_missing_content():
+def mocked_request_no_content():
+    return MockResponse(status_code=204, text="")
+
+
+def mocked_request_not_found():
     return MockResponse(status_code=404, text="")
 
 

--- a/yoti_python_sdk/tests/doc_scan/test_doc_scan_client.py
+++ b/yoti_python_sdk/tests/doc_scan/test_doc_scan_client.py
@@ -13,7 +13,8 @@ from yoti_python_sdk.tests.doc_scan.mocks import (
     mocked_request_failed_session_creation,
     mocked_request_failed_session_retrieval,
     mocked_request_media_content,
-    mocked_request_missing_content,
+    mocked_request_no_content,
+    mocked_request_not_found,
     mocked_request_server_error,
     mocked_request_successful_session_creation,
     mocked_request_successful_session_retrieval,
@@ -111,7 +112,7 @@ def test_should_raise_exception_for_delete_session(_, doc_scan_client):
 
 @mock.patch(
     "yoti_python_sdk.http.SignedRequest.execute",
-    side_effect=mocked_request_missing_content,
+    side_effect=mocked_request_not_found,
 )
 def test_should_raise_exception_for_invalid_content(_, doc_scan_client):
     """
@@ -141,7 +142,20 @@ def test_should_return_media_value(_, doc_scan_client):
 
 @mock.patch(
     "yoti_python_sdk.http.SignedRequest.execute",
-    side_effect=mocked_request_missing_content,
+    side_effect=mocked_request_no_content,
+)
+def test_should_return_none_for_media_no_content(_, doc_scan_client):
+    """
+    :type doc_scan_client: DocScanClient
+    """
+    media = doc_scan_client.get_media_content(SOME_SESSION_ID, SOME_MEDIA_ID)
+
+    assert media is None
+
+
+@mock.patch(
+    "yoti_python_sdk.http.SignedRequest.execute",
+    side_effect=mocked_request_not_found,
 )
 def test_should_throw_exception_for_delete_media(_, doc_scan_client):
     """
@@ -170,7 +184,7 @@ def test_should_return_supported_documents_response(_, doc_scan_client):
 
 @mock.patch(
     "yoti_python_sdk.http.SignedRequest.execute",
-    side_effect=mocked_request_missing_content,
+    side_effect=mocked_request_not_found,
 )
 def test_should_throw_exception_for_supported_documents(_, doc_scan_client):
     """


### PR DESCRIPTION
### Fixed
- `DocScanClient.get_media_content()` will now return `None` for `204` no content responses