### PR TITLE
SDK-1615: Dynamic Scenario

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "asn1==2.2.0",
         "pyopenssl>=18.0.0",
         "iso8601==0.1.13",
+        "pytz==2020.4",
     ],
     extras_require={
         "examples": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,3 +7,4 @@ sonar.exclusions = yoti_python_sdk/tests/**,examples/**,yoti_python_sdk/protobuf
 
 sonar.python.pylint.reportPath = coverage.out
 sonar.verbose = true
+sonar.coverage.exclusions = yoti_python_sdk/version.py

--- a/yoti_python_sdk/dynamic_sharing_service/extension/__init__.py
+++ b/yoti_python_sdk/dynamic_sharing_service/extension/__init__.py
@@ -1,9 +1,11 @@
 from .extension_builder import ExtensionBuilder
 from .location_constraint_extension_builder import LocationConstraintExtensionBuilder
 from .transactional_flow_extension_builder import TransactionalFlowExtensionBuilder
+from .third_party_attribute_extension import ThirdPartyAttributeExtension
 
 __all__ = [
     "ExtensionBuilder",
     "LocationConstraintExtensionBuilder",
     "TransactionalFlowExtensionBuilder",
+    "ThirdPartyAttributeExtension",
 ]

--- a/yoti_python_sdk/dynamic_sharing_service/policy/dynamic_policy_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/policy/dynamic_policy_builder.py
@@ -38,6 +38,10 @@ class DynamicPolicyBuilder(object):
         if constraints:
             attributeBuilder.with_constraint(constraints)
 
+        accept_self_asserted = kwargs.get("accept_self_asserted", None)
+        if accept_self_asserted is not None:
+            attributeBuilder.with_accept_self_asserted(accept_self_asserted)
+
     def with_wanted_attribute_by_name(self, wanted_name, **kwargs):
         """
         @param wanted_name The name of the attribute to include

--- a/yoti_python_sdk/dynamic_sharing_service/policy/dynamic_policy_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/policy/dynamic_policy_builder.py
@@ -122,6 +122,11 @@ class DynamicPolicyBuilder(object):
             config.ATTRIBUTE_DOCUMENT_DETAILS, **kwargs
         )
 
+    def with_document_images(self, **kwargs):
+        return self.with_wanted_attribute_by_name(
+            config.ATTRIBUTE_DOCUMENT_IMAGES, **kwargs
+        )
+
     """
     @param wanted_auth_type
     """

--- a/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_dynamic_policy_builder.py
+++ b/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_dynamic_policy_builder.py
@@ -47,10 +47,11 @@ def test_build_with_simple_attributes():
     builder.with_selfie()
     builder.with_email()
     builder.with_document_details()
+    builder.with_document_images()
     policy = builder.build()
 
     attr_names = [attr["name"] for attr in policy["wanted"]]
-    assert len(policy["wanted"]) == 12
+    assert len(policy["wanted"]) == 13
     assert config.ATTRIBUTE_FAMILY_NAME in attr_names
     assert config.ATTRIBUTE_GIVEN_NAMES in attr_names
     assert config.ATTRIBUTE_FULL_NAME in attr_names
@@ -63,6 +64,7 @@ def test_build_with_simple_attributes():
     assert config.ATTRIBUTE_SELFIE in attr_names
     assert config.ATTRIBUTE_EMAIL_ADDRESS in attr_names
     assert config.ATTRIBUTE_DOCUMENT_DETAILS in attr_names
+    assert config.ATTRIBUTE_DOCUMENT_IMAGES in attr_names
 
 
 def test_build_with_age_derived_attributes():

--- a/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_dynamic_policy_builder.py
+++ b/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_dynamic_policy_builder.py
@@ -130,3 +130,18 @@ def test_attributes_with_constraints():
     constraint = SourceConstraintBuilder().with_national_id().build()
     policy = DynamicPolicyBuilder().with_nationality(constraints=constraint).build()
     assert len(policy["wanted"][0]["constraints"]) == 1
+
+
+def test_attributes_with_accept_self_asserted_true():
+    policy = DynamicPolicyBuilder().with_nationality(accept_self_asserted=True).build()
+    assert policy["wanted"][0]["accept_self_asserted"] is True
+
+
+def test_attributes_with_accept_self_asserted_false():
+    policy = DynamicPolicyBuilder().with_nationality(accept_self_asserted=False).build()
+    assert policy["wanted"][0]["accept_self_asserted"] is False
+
+
+def test_attributes_without_accept_self_asserted():
+    policy = DynamicPolicyBuilder().with_nationality().build()
+    assert not hasattr(policy["wanted"][0], "accept_self_asserted")


### PR DESCRIPTION
### Added
- `DynamicPolicyBuilder().with_document_images()`
- `accept_self_asserted` option can now be passed to `DynamicPolicyBuilder` methods

### Fixed
- Added `pytz` requirement to _setup.py_
- `ThirdPartyAttributeExtension` can now be imported from `yoti_python_sdk.dynamic_sharing_service.extension`
