### PR TITLE
SDK-2027: adding non-latin support for session and supported documents

### DIFF
--- a/yoti_python_sdk/doc_scan/session/create/filter/orthogonal_restrictions_filter.py
+++ b/yoti_python_sdk/doc_scan/session/create/filter/orthogonal_restrictions_filter.py
@@ -68,11 +68,12 @@ class TypeRestriction(YotiSerializable):
 
 
 class OrthogonalRestrictionsFilter(DocumentFilter):
-    def __init__(self, country_restriction, type_restriction):
+    def __init__(self, country_restriction, type_restriction, allow_non_latin_documents=None):
         DocumentFilter.__init__(self, filter_type=ORTHOGONAL_RESTRICTIONS)
 
         self.__country_restriction = country_restriction
         self.__type_restriction = type_restriction
+        self.__allow_non_latin_documents = allow_non_latin_documents
 
     @property
     def country_restriction(self):
@@ -94,10 +95,23 @@ class OrthogonalRestrictionsFilter(DocumentFilter):
         """
         return self.__type_restriction
 
+    @property
+    def allow_non_latin_documents(self):
+        """
+        Returns the flag for whether non-latin documents are allowed.
+
+        :return: allow_non_latin_documents
+        :rtype: bool
+        """
+        return self.__allow_non_latin_documents
+
     def to_json(self):
         parent = DocumentFilter.to_json(self)
         parent["country_restriction"] = self.country_restriction
         parent["type_restriction"] = self.type_restriction
+        if self.__allow_non_latin_documents is not None:
+            parent["allow_non_latin_documents"] = self.__allow_non_latin_documents
+
         return remove_null_values(parent)
 
 
@@ -117,6 +131,7 @@ class OrthogonalRestrictionsFilterBuilder(object):
     def __init__(self):
         self.__country_restriction = None
         self.__type_restriction = None
+        self.__allow_non_latin_documents = None
 
     def with_whitelisted_country_codes(self, country_codes):
         """
@@ -170,6 +185,26 @@ class OrthogonalRestrictionsFilterBuilder(object):
         self.__type_restriction = TypeRestriction(INCLUSION_BLACKLIST, document_types)
         return self
 
+    def allow_non_latin_documents(self):
+        """
+        Sets a True value for "allow non-latin documents" flag.
+
+        :return: the builder
+        :rtype: OrthogonalRestrictionsFilterBuilder
+        """
+        self.__allow_non_latin_documents = True
+        return self
+
+    def disable_non_latin_documents(self):
+        """
+        Sets a False value for "allow non-latin documents" flag.
+
+        :return: the builder
+        :rtype: OrthogonalRestrictionsFilterBuilder
+        """
+        self.__allow_non_latin_documents = False
+        return self
+
     def build(self):
         """
         Builds the orthogonal filter, using the supplied whitelisted/blacklisted values
@@ -178,5 +213,5 @@ class OrthogonalRestrictionsFilterBuilder(object):
         :rtype: OrthogonalRestrictionsFilter
         """
         return OrthogonalRestrictionsFilter(
-            self.__country_restriction, self.__type_restriction
+            self.__country_restriction, self.__type_restriction, self.__allow_non_latin_documents
         )

--- a/yoti_python_sdk/doc_scan/support/supported_documents.py
+++ b/yoti_python_sdk/doc_scan/support/supported_documents.py
@@ -4,10 +4,15 @@ class SupportedDocument(object):
             data = dict()
 
         self.__type = data.get("type", None)
+        self.__is_strictly_latin = data.get("is_strictly_latin", None)
 
     @property
     def type(self):
         return self.__type
+
+    @property
+    def is_strictly_latin(self):
+        return self.__is_strictly_latin
 
 
 class SupportedCountry(object):

--- a/yoti_python_sdk/dynamic_sharing_service/policy/source_constraint_builder.py
+++ b/yoti_python_sdk/dynamic_sharing_service/policy/source_constraint_builder.py
@@ -15,6 +15,7 @@ class SourceConstraintBuilder(object):
     def __init__(self):
         self.__soft_preference = False
         self.__anchors = []
+        self.__is_strictly_latin = None
 
     def with_soft_preference(self, value=True):
         """
@@ -64,14 +65,27 @@ class SourceConstraintBuilder(object):
         """
         return self.with_anchor_by_name(ANCHOR_VALUE_DRIVING_LICENCE, subtype)
 
+    def allow_strictly_latin(self):
+        self.__is_strictly_latin = True
+        return self
+
+    def disable_strictly_latin(self):
+        self.__is_strictly_latin = False
+        return self
+
     def build(self):
         """
         :returns: A dict describing the source constraint
         """
-        return {
+        constrain = {
             "type": "SOURCE",
             "preferred_sources": {
                 "soft_preference": self.__soft_preference,
                 "anchors": self.__anchors,
             },
         }
+
+        if self.__is_strictly_latin is not None:
+            constrain["is_strictly_latin"] = self.__is_strictly_latin
+
+        return constrain

--- a/yoti_python_sdk/tests/doc_scan/session/create/subcheck/test_issuing_authority_sub_check.py
+++ b/yoti_python_sdk/tests/doc_scan/session/create/subcheck/test_issuing_authority_sub_check.py
@@ -29,6 +29,21 @@ class IssuingAuthoritySubCheckTest(unittest.TestCase):
 
         assert issuing_authority_sub_check.requested is True
 
+    def test_allow_non_latin_documents_set_to_true(self):
+        filter = OrthogonalRestrictionsFilterBuilder().allow_non_latin_documents().build()
+
+        assert filter.allow_non_latin_documents is True
+
+    def test_allow_non_latin_documents_set_to_false(self):
+        filter = OrthogonalRestrictionsFilterBuilder().disable_non_latin_documents().build()
+
+        assert filter.allow_non_latin_documents is False
+
+    def test_default_non_latin_documents(self):
+        filter = OrthogonalRestrictionsFilterBuilder().build()
+
+        assert 'allow_non_latin_documents' not in filter.to_json()
+
     def test_build_invalid_filter(self):
         filter = 'invalid'
 

--- a/yoti_python_sdk/tests/doc_scan/support/test_supported_documents.py
+++ b/yoti_python_sdk/tests/doc_scan/support/test_supported_documents.py
@@ -18,6 +18,24 @@ def test_supported_document_should_not_throw_exception_on_missing_data():
     assert result.type is None
 
 
+def test_supported_document_created_with_is_strictly_latin_as_true():
+    result = SupportedDocument({"is_strictly_latin": True})
+
+    assert result.is_strictly_latin is True
+
+
+def test_supported_document_created_with_is_strictly_latin_as_false():
+    result = SupportedDocument({"is_strictly_latin": False})
+
+    assert result.is_strictly_latin is False
+
+
+def test_supported_document_created_without_is_strictly_latin():
+    result = SupportedDocument({"type": "someSupportedDocument"})
+
+    assert result.is_strictly_latin is None
+
+
 def test_supported_country_should_parse_data():
     data = {
         "code": "someCode",

--- a/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_source_constraint_builder.py
+++ b/yoti_python_sdk/tests/dynamic_sharing_service/policy/test_source_constraint_builder.py
@@ -33,3 +33,21 @@ def test_with_soft_preference():
     assert ANCHOR_VALUE_DRIVING_LICENCE in [a["name"] for a in anchors]
     assert ANCHOR_VALUE_PASSPORT in [a["name"] for a in anchors]
     assert constraint["preferred_sources"]["soft_preference"]
+
+
+def test_with_is_strictly_latin_set_true():
+    constraint = SourceConstraintBuilder().allow_strictly_latin().build()
+
+    assert constraint["is_strictly_latin"] is True
+
+
+def test_with_is_strictly_latin_set_false():
+    constraint = SourceConstraintBuilder().disable_strictly_latin().build()
+
+    assert constraint["is_strictly_latin"] is False
+
+
+def test_with_is_strictly_latin_default():
+    constraint = SourceConstraintBuilder().build()
+
+    assert "is_strictly_latin" not in constraint


### PR DESCRIPTION
adding non-latin support for session and supported documents