### PR TITLE
Celery >=5.2.1 compatibility to unblock CVE patch

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ pbr==1.10.0
 protobuf==3.13.0
 pyopenssl==19.1.0
 PyYAML==5.2 # PyYAML 5.3 does not support Python 3.4
-pytz==2020.4
+pytz==2022.1
 requests>=2.20.0
 urllib3>=1.24.3
 deprecated==1.2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pbr==1.10.0               # via -r requirements.in
 protobuf==3.13.0          # via -r requirements.in
 pycparser==2.18           # via cffi
 pyopenssl==19.1.0         # via -r requirements.in
-pytz==2020.4              # via -r requirements.in
+pytz==2022.1              # via -r requirements.in
 pyyaml==5.2               # via -r requirements.in
 requests==2.21.0          # via -r requirements.in
 six==1.10.0               # via cryptography, protobuf, pyopenssl

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "asn1==2.2.0",
         "pyopenssl>=18.0.0",
         "iso8601==0.1.13",
-        "pytz==2020.4",
+        "pytz==2022.1",
     ],
     extras_require={
         "examples": [


### PR DESCRIPTION
yoti-python-sdk has a pytz dependency that prevents upgrading Celery past 5.2 - this blocks projects that use both libraries from patching the following high severity CVE: https://github.com/advisories/GHSA-q4xr-rc97-m4xx

Please consider this PR as soon as you are able.

Thanks!