### PR TITLE
(urgent) bugfix: mismatch in protobuf dep between requirements.txt and setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         "deprecated==1.2.10",
         "cryptography>=2.2.1",
-        "protobuf>=3.1.0",
+        "protobuf==3.13.0",
         "requests>=2.11.1",
         "future>=0.11.0",
         "asn1==2.2.0",


### PR DESCRIPTION
This is the source of a bug in which this package will break other systems by allowing the incompatible version 4.* of protobuf to be installed.

We are having to pin the version of protobuf ourselves in order to get around this issue.

Traceback:
`File "yoti-python-sdk-rightly\yoti_python_sdk\protobuf\attribute_public_api\ContentType_pb2.py", line 32, in <module>
    _descriptor.EnumValueDescriptor(
  File "lib\site-packages\google\protobuf\descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates`