### PR TITLE
SDK-2743-python-expose-idv-breakdown-process-property

### DIFF
--- a/yoti_python_sdk/doc_scan/session/retrieve/breakdown_response.py
+++ b/yoti_python_sdk/doc_scan/session/retrieve/breakdown_response.py
@@ -14,6 +14,7 @@ class BreakdownResponse(object):
         """
         self.__sub_check = data.get("sub_check", None)
         self.__result = data.get("result", None)
+        self.__process = data.get("process", None)
         self.__details = [DetailsResponse(detail) for detail in data.get("details", [])]
 
     @property
@@ -35,6 +36,16 @@ class BreakdownResponse(object):
         :rtype: str or None
         """
         return self.__result
+
+    @property
+    def process(self):
+        """
+        The process of the sub check
+
+        :return: the process
+        :rtype: str or None
+        """
+        return self.__process
 
     @property
     def details(self):

--- a/yoti_python_sdk/doc_scan/session/retrieve/breakdown_response.py
+++ b/yoti_python_sdk/doc_scan/session/retrieve/breakdown_response.py
@@ -40,9 +40,9 @@ class BreakdownResponse(object):
     @property
     def process(self):
         """
-        The process of the sub check
+        The breakdown process type for the sub-check (e.g. AUTOMATED or EXPERT_REVIEW)
 
-        :return: the process
+        :return: the breakdown process type
         :rtype: str or None
         """
         return self.__process

--- a/yoti_python_sdk/tests/doc_scan/session/retrieve/test_breakdown_response.py
+++ b/yoti_python_sdk/tests/doc_scan/session/retrieve/test_breakdown_response.py
@@ -24,9 +24,9 @@ class BreakdownResponseTest(unittest.TestCase):
 
         result = BreakdownResponse(data)
 
-        assert result.sub_check is self.SOME_SUB_CHECK
-        assert result.result is self.SOME_RESULT
-        assert result.process is self.SOME_PROCESS
+        assert result.sub_check == self.SOME_SUB_CHECK
+        assert result.result == self.SOME_RESULT
+        assert result.process == self.SOME_PROCESS
         assert len(result.details) == 2
         assert result.details[0].name == "firstDetailName"
         assert result.details[0].value == "firstDetailValue"

--- a/yoti_python_sdk/tests/doc_scan/session/retrieve/test_breakdown_response.py
+++ b/yoti_python_sdk/tests/doc_scan/session/retrieve/test_breakdown_response.py
@@ -8,6 +8,7 @@ from yoti_python_sdk.doc_scan.session.retrieve.breakdown_response import (
 class BreakdownResponseTest(unittest.TestCase):
     SOME_SUB_CHECK = "someSubCheck"
     SOME_RESULT = "someResult"
+    SOME_PROCESS = "AUTOMATED"
     SOME_DETAILS = [
         {"name": "firstDetailName", "value": "firstDetailValue"},
         {"name": "secondDetailName", "value": "secondDetailValue"},
@@ -17,6 +18,7 @@ class BreakdownResponseTest(unittest.TestCase):
         data = {
             "sub_check": self.SOME_SUB_CHECK,
             "result": self.SOME_RESULT,
+            "process": self.SOME_PROCESS,
             "details": self.SOME_DETAILS,
         }
 
@@ -24,6 +26,7 @@ class BreakdownResponseTest(unittest.TestCase):
 
         assert result.sub_check is self.SOME_SUB_CHECK
         assert result.result is self.SOME_RESULT
+        assert result.process is self.SOME_PROCESS
         assert len(result.details) == 2
         assert result.details[0].name == "firstDetailName"
         assert result.details[0].value == "firstDetailValue"
@@ -31,6 +34,7 @@ class BreakdownResponseTest(unittest.TestCase):
     def test_should_default_details_to_empty_list(self):
         result = BreakdownResponse({})
         assert len(result.details) == 0
+        assert result.process is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary
  - Add `process` property to `BreakdownResponse` to expose the breakdown process type
  (AUTOMATED / EXPERT_REVIEW)
  - Field is a nullable string, defaults to None when absent